### PR TITLE
Switch flex for footer to auto

### DIFF
--- a/assets/scss/partials/Footer.scss
+++ b/assets/scss/partials/Footer.scss
@@ -19,7 +19,7 @@
     }
 
     .Version {
-        flex: 1;
+        flex: auto;
         color: $grey;
         display: flex;
         justify-content: flex-end;


### PR DESCRIPTION
This allows for longer named versions to use up more of the Flex1 div
elements to allow for the version line to not have to wrap.  Without this, "Puppet© Container Registry Enterprise - Version 1.3-SNAPSHOT/319987" wraps to two lines.