### PR TITLE
Implement Force HTTPS

### DIFF
--- a/assets/js/actions/SSLActions.js
+++ b/assets/js/actions/SSLActions.js
@@ -200,7 +200,6 @@ export function isSSLValid(sslSettings) {
 		serverPrivateKey: 'Server Private Key',
 		serverCertificate: 'Server Certificate',
 		authorityCertificate: 'Authority Certificate',
-		forceHttps: 'Force HTTPS',
 	};
 
 	let isValid = Validate(sslSettings, required);

--- a/assets/js/actions/SSLActions.js
+++ b/assets/js/actions/SSLActions.js
@@ -13,11 +13,12 @@ export function sslState() {
 		sslEnabled: false,
 		ogSslEnabled: false,
 		hasChanges: false,
-		sslCreds: {
+		sslSettings: {
 			dnsName: '',
 			serverPrivateKey: '',
 			serverCertificate: '',
 			authorityCertificate: '',
+			forceHttps: false,
 		},
 		errorFields: {
 			names: [],
@@ -57,32 +58,40 @@ export function toggleEnableSSL() {
 	});
 }
 
-export function updateSSLCreds(prop, e, eIsValue = false) {
-	let value = (eIsValue) ? e : e.target.value;
-
+export function toggleForceHttps() {
 	this.setState({
 		ssl: GA.modifyProperty(this.state.ssl, {
 			saveSuccess: false,
 			hasChanges: true,
-			sslCreds: {
-				...this.state.ssl.sslCreds,
-				[prop]: value
+			sslSettings: {
+				...this.state.ssl.sslSettings,
+				['forceHttps']: !this.state.ssl.sslSettings.forceHttps
 			}
 		})
 	});
 }
 
+export function updateSSLSettings(prop, e, eIsValue = false) {
+	let value = (eIsValue) ? e : e.target.value;
+	let newState = {
+		ssl: GA.modifyProperty(this.state.ssl, {
+			saveSuccess: false,
+			hasChanges: true,
+			sslSettings: {
+				...this.state.ssl.sslSettings,
+				[prop]: value
+			}
+		})
+	};
 
-export function updateDNSName(dnsName) {
-	this.setState({
-		dnsName: dnsName
-	});
+	this.setState(newState);
 }
+
 
 export function saveSSLSettings() {
 	return new Promise((resolve, reject) => {
 
-		let creds = this.state.ssl.sslCreds
+		let creds = this.state.ssl.sslSettings
 		let isEnabled = NPECheck(this.state, 'ssl/sslEnabled', false)
 
 		if (isEnabled) {
@@ -99,10 +108,10 @@ export function saveSSLSettings() {
 				return
 			}
 
-
 		} else {
 			creds = {
-				dnsName: NPECheck(this.state, 'ssl/sslCreds/dnsName')
+				dnsName: NPECheck(this.state, 'ssl/sslSettings/dnsName'),
+				forceHttps: NPECheck(this.state, 'ssl/sslSettings/forceHttps')
 			}
 		}
 
@@ -152,12 +161,11 @@ export function getSSLSettings() {
 					this.setState({
 						ssl: GA.modifyProperty(this.state.ssl, {
 							getXHR: false,
-							sslCreds: res,
+							sslSettings: res,
+							sslEnabled: sslEnabled,
 							ogSslEnabled: sslEnabled,
 							hasChanges: false,
-							sslEnabled: sslEnabled,
 							isBlocked: false,
-
 						})
 					}, () => resolve(res));
 				})
@@ -192,6 +200,7 @@ export function isSSLValid(sslSettings) {
 		serverPrivateKey: 'Server Private Key',
 		serverCertificate: 'Server Certificate',
 		authorityCertificate: 'Authority Certificate',
+		forceHttps: 'Force HTTPS',
 	};
 
 	let isValid = Validate(sslSettings, required);

--- a/assets/js/components/Checkbox.js
+++ b/assets/js/components/Checkbox.js
@@ -17,6 +17,10 @@ export default class Checkbox extends Component {
 				className += ' Inactive';
 			}
 
+			if(this.props.disabled) {
+				className += ' Disabled';
+			}
+
 			return (
 				<label className={className}
 				       style={{margin: '0'}}>
@@ -26,8 +30,12 @@ export default class Checkbox extends Component {
 		}
 	}
 	renderIcon(){
-		let className = (this.props.isChecked) ? 'icon icon-dis-box-check' 
+		let className = (this.props.isChecked) ? 'icon icon-dis-box-check'
 											   : 'icon icon-dis-box-uncheck Inactive';
+
+		if(this.props.disabled) {
+			className += ' Disabled';
+		}
 
 		if(this.props.iconClassName) {
 			className += ` ${this.props.iconClassName}`;
@@ -51,6 +59,7 @@ Checkbox.propTypes = {
 	label: PropTypes.string,
 	onClick: PropTypes.func.isRequired,
 	isChecked: PropTypes.bool.isRequired,
+	disabled: PropTypes.bool,
 	iconClassName: PropTypes.string,
 	labelClassName: PropTypes.string
 };

--- a/assets/js/components/SSLSettings.js
+++ b/assets/js/components/SSLSettings.js
@@ -81,9 +81,7 @@ export default class SSLSettings extends Component {
 					<label>DNS Name</label>
 					<input ref="dnsName" className={className} value={dnsValue} onChange={(e) => this.context.actions.updateSSLSettings(dnsNameKey, e)} />
 				</div>
-				<div className="FlexRow">
-					<Checkbox onClick={() => this.context.actions.toggleForceHttps()} label="Force HTTPS" isChecked={NPECheck(this.props, 'ssl/sslSettings/forceHttps', false)}/>
-				</div>
+				{this.renderForceHttps()}
 				<div className="FlexRow">
 					<Checkbox onClick={() => this.context.actions.toggleEnableSSL()} label="SSL Enabled" isChecked={NPECheck(this.props, 'ssl/sslEnabled', false)}/>
 					{this.renderUnsavedChanges()}
@@ -94,6 +92,26 @@ export default class SSLSettings extends Component {
 			</div>
 		);
 	}
+
+	renderForceHttps(){
+		let isEnabled = (window.location.protocol == 'https:');
+		if(isEnabled) {
+			return (
+				<div className="FlexRow">
+					<Checkbox onClick={() => this.context.actions.toggleForceHttps()} label="Force HTTPS" isChecked={NPECheck(this.props, 'ssl/sslSettings/forceHttps', false)}/>
+				</div>
+			);
+		}
+		else {
+			return (
+				<div className="FlexRow">
+					<Checkbox onClick={() => {}} label="Force HTTPS" isChecked={NPECheck(this.props, 'ssl/sslSettings/forceHttps', false)} disabled={true}/>
+					<span className="CheckboxDisabled">Must access page using HTTPS to modify setting</span>
+				</div>
+			);
+		}
+	}
+
 	renderTextAreas(){
 		if(NPECheck(this.props, 'ssl/sslEnabled', false)) {
 

--- a/assets/js/components/SSLSettings.js
+++ b/assets/js/components/SSLSettings.js
@@ -32,7 +32,7 @@ export default class SSLSettings extends Component {
 	saveSSLSettings(){
 		this.context.actions.saveSSLSettings()
 		.then(this.context.actions.getSSLSettings)
-		.then((sslSettings) => this.context.actions.updateDNSName(sslSettings.dnsName))
+		//.then((sslSettings) => this.context.actions.updateDNSName(sslSettings.dnsName))
 		.catch((err) => {
 			console.error(err);
 		});
@@ -55,19 +55,20 @@ export default class SSLSettings extends Component {
 		return className;
 	}
 	renderSSLTextarea(config, i){
-		let value = NPECheck(this.props, `ssl/sslCreds/${config.key}`, '');
+		let value = NPECheck(this.props, `ssl/sslSettings/${config.key}`, '');
 		return (
 			<div className="FlexColumn" key={i}>
 				<label>{config.label}</label>
-				<textarea className={this.getTextareaClassName(config.key)} 
-						  value={value} 
-						  onChange={(e) => this.context.actions.updateSSLCreds(config.key, e)}>
+				<textarea className={this.getTextareaClassName(config.key)}
+						  value={value}
+						  onChange={(e) => this.context.actions.updateSSLSettings(config.key, e)}>
 				</textarea>
 			</div>
 		);
 	}
+
 	renderSSLInputs(){
-		let dnsValue = NPECheck(this.props, `ssl/sslCreds/${dnsNameKey}`, '');
+		let dnsValue = NPECheck(this.props, `ssl/sslSettings/${dnsNameKey}`, '');
 		let className = "BlueBorder FullWidth";
 
 		if(this.props.isLoggedIn) {
@@ -78,7 +79,10 @@ export default class SSLSettings extends Component {
 			<div className="FlexColumn">
 				<div className="FlexColumn">
 					<label>DNS Name</label>
-					<input ref="dnsName" className={className} value={dnsValue} onChange={(e) => this.context.actions.updateSSLCreds(dnsNameKey, e)} />
+					<input ref="dnsName" className={className} value={dnsValue} onChange={(e) => this.context.actions.updateSSLSettings(dnsNameKey, e)} />
+				</div>
+				<div className="FlexRow">
+					<Checkbox onClick={() => this.context.actions.toggleForceHttps()} label="Force HTTPS" isChecked={NPECheck(this.props, 'ssl/sslSettings/forceHttps', false)}/>
 				</div>
 				<div className="FlexRow">
 					<Checkbox onClick={() => this.context.actions.toggleEnableSSL()} label="SSL Enabled" isChecked={NPECheck(this.props, 'ssl/sslEnabled', false)}/>
@@ -107,9 +111,10 @@ export default class SSLSettings extends Component {
 					key: caKey
 				}
 			];
-			return textareaConfigs.map((config, i) => this.renderSSLTextarea(config, i))	
+			return textareaConfigs.map((config, i) => this.renderSSLTextarea(config, i))
 		}
 	}
+
 	renderButton(){
 		if(NPECheck(this.props, 'ssl/saveXHR', false)) {
 			return (
@@ -125,9 +130,9 @@ export default class SSLSettings extends Component {
 			errorMsg2 = (errorMsg2) ? `Missing Required Fields: ${errorMsg2}` : null;
 
 			return (
-				<Msg text={(errorMsg || errorMsg2)} 
+				<Msg text={(errorMsg || errorMsg2)}
     				 close={() => this.context.actions.clearSSLErrors()}
-    				 style={{padding: '1rem 0'}}/> 
+    				 style={{padding: '1rem 0'}}/>
 			);
 		}
 
@@ -154,9 +159,9 @@ export default class SSLSettings extends Component {
 
 		if(success) {
 			return (
-				<Msg text="Successfully saved SSL settings." 
+				<Msg text="Successfully saved SSL settings."
 					 isSuccess={true}
-    				 style={{padding: '1rem 0'}}/> 
+    				 style={{padding: '1rem 0'}}/>
 			);
 		}
 	}

--- a/assets/scss/partials/RadioButton.scss
+++ b/assets/scss/partials/RadioButton.scss
@@ -14,6 +14,14 @@
         color: $grey;
     }
 
+    label.Disabled {
+        text-decoration: line-through;
+
+        &:hover {
+            cursor: initial;
+        }
+    }
+
     i {
         margin-right: 5px;
 
@@ -24,5 +32,11 @@
 
     i.Inactive {
         color: $grey;
+    }
+
+    i.Disabled {
+        &:hover {
+            cursor: initial;
+        }
     }
 }

--- a/assets/scss/partials/SSLSettings.scss
+++ b/assets/scss/partials/SSLSettings.scss
@@ -18,13 +18,20 @@
         height: 200px;
     }
 
-    .UnsavedChanges {
+    .UnsavedChanges, .CheckboxDisabled {
         font-size: 0.75rem;
-        color: $red;
         width: 154px;
         left: 50%;
         position: relative;
         margin-left: -163px;
+    }
+
+    .UnsavedChanges {
+        color: $red;
+    }
+
+    .CheckboxDisabled {
+        color: $grey;
     }
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <distelli-common.version>9.13.1</distelli-common.version>
+    <distelli-common.version>9.13.2</distelli-common.version>
     <distelli-persistence.version>3.5.5</distelli-persistence.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
   <url>http://internal.distelli.com/</url>
 
   <scm>
-    <connection>scm:git:git@github.com:Distelli/europa.git</connection>
-    <url>https://github.com/Distelli/europa.git</url>
+    <connection>scm:git:git@github.com:puppetlabs/europa.git</connection>
+    <url>https://github.com/puppetlabs/europa.git</url>
     <tag>HEAD</tag>
   </scm>
 

--- a/src/main/java/com/distelli/europa/Europa.java
+++ b/src/main/java/com/distelli/europa/Europa.java
@@ -17,6 +17,7 @@ import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.distelli.europa.filters.ForceHttpsFilter;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.ErrorHandler;
 import org.eclipse.jetty.servlet.DefaultServlet;
@@ -130,7 +131,7 @@ public class Europa
 
     protected void initializeWebServer(Injector injector)
     {
-        _webappFilters = Arrays.asList(injector.getInstance(StorageInitFilter.class));
+        _webappFilters = Arrays.asList(injector.getInstance(StorageInitFilter.class), injector.getInstance(ForceHttpsFilter.class));
         _registryApiFilters = Arrays.asList(injector.getInstance(RegistryAuthFilter.class));
 
         _requestContextFactory = new RequestContextFactory() {

--- a/src/main/java/com/distelli/europa/filters/ForceHttpsFilter.java
+++ b/src/main/java/com/distelli/europa/filters/ForceHttpsFilter.java
@@ -1,0 +1,56 @@
+package com.distelli.europa.filters;
+
+import com.distelli.europa.EuropaRequestContext;
+import com.distelli.europa.models.SslSettings;
+import com.distelli.webserver.RequestFilter;
+import com.distelli.webserver.RequestFilterChain;
+import com.distelli.webserver.WebConstants;
+import com.distelli.webserver.WebResponse;
+import lombok.extern.log4j.Log4j;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import java.util.ArrayList;
+import java.util.List;
+
+@Log4j
+public class ForceHttpsFilter implements RequestFilter<EuropaRequestContext>
+{
+    @Inject
+    protected Provider<SslSettings> _sslSettingsProvider;
+
+    public ForceHttpsFilter()
+    {
+
+    }
+
+    @Override
+    public WebResponse filter(EuropaRequestContext requestContext, RequestFilterChain next)
+    {
+        String protocol = requestContext.getProto();
+        String path = requestContext.getPath();
+        // The health check endpoint needs to work over HTTP
+        if(protocol.equalsIgnoreCase("http") && !path.equalsIgnoreCase("/healthz")) {
+            SslSettings sslSettings = _sslSettingsProvider.get();
+            if (sslSettings.getForceHttps()) {
+                List<String> newLocationParts = new ArrayList<>();
+                newLocationParts.add("https://");
+                String hostName = sslSettings.getDnsName();
+                if (null == hostName) {
+                    hostName = requestContext.getHost("");
+                }
+                newLocationParts.add(hostName);
+                newLocationParts.add(requestContext.getOriginalPath());
+                if (null != requestContext.getQueryString()) {
+                    newLocationParts.add("?");
+                    newLocationParts.add(requestContext.getQueryString());
+                }
+                String newLocation = String.join("", newLocationParts);
+                WebResponse redirectResponse = new WebResponse(307);
+                redirectResponse.setResponseHeader(WebConstants.LOCATION_HEADER, newLocation);
+                return redirectResponse;
+            }
+        }
+        return next.filter(requestContext);
+    }
+}

--- a/src/main/java/com/distelli/europa/filters/HttpAlwaysAllowedPaths.java
+++ b/src/main/java/com/distelli/europa/filters/HttpAlwaysAllowedPaths.java
@@ -1,0 +1,26 @@
+package com.distelli.europa.filters;
+
+import javax.inject.Singleton;
+import java.util.HashSet;
+import java.util.Set;
+
+@Singleton
+public class HttpAlwaysAllowedPaths {
+
+    private static final Set<String> HTTP_ALWAYS_ALLOWED_PATHS = new HashSet<String>();
+
+    static {
+        HTTP_ALWAYS_ALLOWED_PATHS.add("/healthz");
+    }
+
+    public HttpAlwaysAllowedPaths() {
+
+    }
+
+    public boolean isHttpAlwaysAllowedPath(String path) {
+        if (HTTP_ALWAYS_ALLOWED_PATHS.contains(path)) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/distelli/europa/guice/SslSettingsProvider.java
+++ b/src/main/java/com/distelli/europa/guice/SslSettingsProvider.java
@@ -36,8 +36,6 @@ public class SslSettingsProvider implements Provider<SslSettings>
 
     public synchronized SslSettings get()
     {
-        if(_sslSettings != null)
-            return _sslSettings;
         List<EuropaSetting> settings = _settingsDb.listRootSettingsByType(EuropaSettingType.SSL);
         _sslSettings = SslSettings.fromEuropaSettings(settings);
         return _sslSettings;

--- a/src/main/java/com/distelli/europa/models/SslSettings.java
+++ b/src/main/java/com/distelli/europa/models/SslSettings.java
@@ -22,16 +22,22 @@ public class SslSettings {
     public static String AUTHORITY_PRIVATE_KEY = "authorityPrivateKey";
     public static String AUTHORITY_CERTIFICATE = "authorityCertificate";
     public static String DNS_NAME = "dnsName";
+    public static String FORCE_HTTPS = "forceHttps";
 
     protected String serverPrivateKey;
     protected String serverCertificate;
     protected String authorityPrivateKey;
     protected String authorityCertificate;
     protected String dnsName;
+    protected Boolean forceHttps;
 
     public static SslSettings fromEuropaSettings(List<EuropaSetting> settings) {
         if ( settings.isEmpty() ) return null;
-        return OM.convertValue(EuropaSetting.asMap(settings), SslSettings.class);
+        Map<String, String> settingsMap = EuropaSetting.asMap(settings);
+        Boolean forceHttpsValue = Boolean.parseBoolean(settingsMap.remove(FORCE_HTTPS));
+        SslSettings convertedSettings = OM.convertValue(settingsMap, SslSettings.class);
+        convertedSettings.setForceHttps(forceHttpsValue);
+        return convertedSettings;
     }
 
     public List<EuropaSetting> toEuropaSettings() {


### PR DESCRIPTION
This adds the Force HTTPS redirect functionality. When enabled, accessing the site over HTTP will trigger a 307 redirect the HTTPS version. The setting can only be enabled when viewing the site over HTTPS in order to prevent users from accidentally enabling the setting and locking themselves out. It also doesn't trigger for the /healthz endpoint, since that needs to be accessible over HTTP for load balancers to work.