### PR TITLE
(maint) Bump maven-javadoc-plugin to 2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.distelli.europa</groupId>
@@ -47,14 +48,14 @@
           </descriptors>
         </configuration>
         <executions>
-      <execution>
-        <id>make-assembly</id> <!-- this is used for inheritance merges -->
-        <phase>package</phase> <!-- append to the packaging phase. -->
-        <goals>
-          <goal>single</goal> <!-- goals == mojos -->
-        </goals>
-      </execution>
-    </executions>
+          <execution>
+            <id>make-assembly</id> <!-- this is used for inheritance merges -->
+            <phase>package</phase> <!-- append to the packaging phase. -->
+            <goals>
+              <goal>single</goal> <!-- goals == mojos -->
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -68,7 +69,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.2</version>
+        <version>2.5</version>
         <configuration>
           <skip>true</skip>
         </configuration>
@@ -78,7 +79,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.5</version>
         <configuration>
-          <argLine />
+          <argLine/>
           <reportFormat>brief</reportFormat>
           <useFile>false</useFile>
           <disableXmlReport>true</disableXmlReport>


### PR DESCRIPTION
The `skip` configuration option was added in 2.5, so without this, the pom.xml
is technically invalid (although maven just ignores the setting).