### PR TITLE
 Fix error on storage settings save

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ europa-config.sh
 europa-test-config.sh
 EuropaConfig.json
 EuropaTestConfig.json
+.idea/*
+*.iml

--- a/src/main/java/com/distelli/europa/filters/ForceHttpsFilter.java
+++ b/src/main/java/com/distelli/europa/filters/ForceHttpsFilter.java
@@ -10,8 +10,6 @@ import lombok.extern.log4j.Log4j;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
-import java.util.ArrayList;
-import java.util.List;
 
 @Log4j
 public class ForceHttpsFilter implements RequestFilter<EuropaRequestContext>
@@ -34,7 +32,7 @@ public class ForceHttpsFilter implements RequestFilter<EuropaRequestContext>
         // The health check endpoint needs to work over HTTP
         if(protocol.equalsIgnoreCase("http") && !_httpAlwaysAllowedPaths.isHttpAlwaysAllowedPath(path)) {
             SslSettings sslSettings = _sslSettingsProvider.get();
-            if (sslSettings.getForceHttps()) {
+            if (sslSettings != null && sslSettings.getForceHttps()) {
                 StringBuilder newLocation = new StringBuilder();
                 newLocation.append("https://");
                 String hostName = sslSettings.getDnsName();


### PR DESCRIPTION
A bug was introduced when the https redirect was added, because sslSettings == null with a fresh database, and so an exception results unless this fix is applied.

I also updated gitignore and intellij removed two unused imports; it's not quite the right place for those changes but I don't think it's big enough to warrant separating out.