### PR TITLE
(WHO-907) Add table prefix support

### DIFF
--- a/src/main/java/com/distelli/europa/EuropaConfiguration.java
+++ b/src/main/java/com/distelli/europa/EuropaConfiguration.java
@@ -27,6 +27,8 @@ public class EuropaConfiguration
     @Getter @Setter
     protected String dbPass;
     @Getter @Setter
+    protected String dbPrefix;
+    @Getter @Setter
     protected int dbMaxPoolSize = 2;
     @Getter @Setter
     protected EuropaStage stage;
@@ -52,6 +54,7 @@ public class EuropaConfiguration
         String dbEndpoint = getEnvVar("EUROPA_DB_ENDPOINT");
         String dbUser = getEnvVar("EUROPA_DB_USER");
         String dbPass = getEnvVar("EUROPA_DB_PASS");
+        String dbPrefix = getEnvVar("EUROPA_DB_PREFIX", false);
         int dbPoolSize = 2;
         String dbPoolSizeStr = null;
         try {
@@ -67,6 +70,7 @@ public class EuropaConfiguration
         config.setDbEndpoint(dbEndpoint);
         config.setDbUser(dbUser);
         config.setDbPass(dbPass);
+        config.setDbPrefix(dbPrefix);
         config.setDbMaxPoolSize(dbPoolSize);
         return config;
     }

--- a/src/main/java/com/distelli/europa/guice/EuropaInjectorModule.java
+++ b/src/main/java/com/distelli/europa/guice/EuropaInjectorModule.java
@@ -152,6 +152,7 @@ public class EuropaInjectorModule extends AbstractModule
         CredPair creds = new CredPair()
         .withKeyId(_europaConfiguration.getDbUser())
         .withSecret(_europaConfiguration.getDbPass());
+        String dbPrefix = _europaConfiguration.getDbPrefix();
 
         OptionalBinder.newOptionalBinder(binder(), PermissionCheck.class)
             .setDefault().to(PermissionCheck.Default.class);
@@ -164,7 +165,7 @@ public class EuropaInjectorModule extends AbstractModule
             .toProvider(() -> new GcrClient.Builder().connectionPool(sharedPool));
         bind(DockerHubClient.Builder.class)
             .toProvider(() -> new DockerHubClient.Builder().connectionPool(sharedPool));
-        bind(Index.Factory.class).toProvider(new IndexFactoryProvider(endpoint, creds));
+        bind(Index.Factory.class).toProvider(new IndexFactoryProvider(endpoint, creds, dbPrefix));
         configureEuropaConfiguration();
         bind(ObjectStore.class).toProvider(new ObjectStoreProvider());
         bind(DnsSettings.class).toProvider(new DnsSettingsProvider());

--- a/src/main/java/com/distelli/europa/guice/IndexFactoryProvider.java
+++ b/src/main/java/com/distelli/europa/guice/IndexFactoryProvider.java
@@ -63,7 +63,7 @@ public class IndexFactoryProvider implements Provider<Index.Factory>
         _scaleFactor = scaleFactor;
         _endpoint = defaultEndpoint;
         _creds = defaultCreds;
-        _tableNameFormat = (null == dbPrefix) ? "%s.europa" : (dbPrefix.replaceAll("\\W", "_") + "-%s.europa");
+        _tableNameFormat = (null == dbPrefix) ? "%s.europa" : (dbPrefix.replace("%", "%%") + "-%s.europa");
         _indexFactory = new Index.Factory() {
                 @Override
                 public <T> Index.Builder<T> create(Class<T> type) {

--- a/src/main/java/com/distelli/europa/guice/IndexFactoryProvider.java
+++ b/src/main/java/com/distelli/europa/guice/IndexFactoryProvider.java
@@ -40,25 +40,35 @@ public class IndexFactoryProvider implements Provider<Index.Factory>
 
     private URI _endpoint;
     private CredPair _creds;
+    private String _tableNameFormat;
     private boolean _init = false;
     private Throwable _initFailure = null;
     private Index.Factory _indexFactory;
     private float _scaleFactor;
 
     public IndexFactoryProvider(URI defaultEndpoint, CredPair defaultCreds) {
-        this(defaultEndpoint, defaultCreds, 1.0f);
+        this(defaultEndpoint, defaultCreds, null, 1.0f);
     }
 
-    public IndexFactoryProvider(URI defaultEndpoint, CredPair defaultCreds, float scaleFactor)
+    public IndexFactoryProvider(URI defaultEndpoint, CredPair defaultCreds, String dbPrefix) {
+        this(defaultEndpoint, defaultCreds, dbPrefix, 1.0f);
+    }
+
+    public IndexFactoryProvider(URI defaultEndpoint, CredPair defaultCreds, float scaleFactor) {
+        this(defaultEndpoint, defaultCreds, null, scaleFactor);
+    }
+
+    public IndexFactoryProvider(URI defaultEndpoint, CredPair defaultCreds, String dbPrefix, float scaleFactor)
     {
         _scaleFactor = scaleFactor;
         _endpoint = defaultEndpoint;
         _creds = defaultCreds;
+        _tableNameFormat = (null == dbPrefix) ? "%s.europa" : dbPrefix+"-%s.europa";
         _indexFactory = new Index.Factory() {
                 @Override
                 public <T> Index.Builder<T> create(Class<T> type) {
                     return _baseIndexFactory.create(type)
-                        .withTableNameFormat("%s.europa") //TODO: Add prefix support
+                        .withTableNameFormat(_tableNameFormat)
                         .withEndpoint(_endpoint)
                         .withCredProvider(() -> _creds);
                 }
@@ -92,7 +102,7 @@ public class IndexFactoryProvider implements Provider<Index.Factory>
         try {
             log.info("DB schema initializing");
             _baseSchemaFactory.create()
-                .withTableNameFormat("%s.europa") //TODO: Add prefix support
+                .withTableNameFormat(_tableNameFormat) //TODO: Add prefix support
                 .withEndpoint(_endpoint)
                 .withCredProvider(() -> _creds)
                 .build()

--- a/src/main/java/com/distelli/europa/guice/IndexFactoryProvider.java
+++ b/src/main/java/com/distelli/europa/guice/IndexFactoryProvider.java
@@ -63,7 +63,7 @@ public class IndexFactoryProvider implements Provider<Index.Factory>
         _scaleFactor = scaleFactor;
         _endpoint = defaultEndpoint;
         _creds = defaultCreds;
-        _tableNameFormat = (null == dbPrefix) ? "%s.europa" : dbPrefix+"-%s.europa";
+        _tableNameFormat = (null == dbPrefix) ? "%s.europa" : (dbPrefix.replaceAll("\\W", "_") + "-%s.europa");
         _indexFactory = new Index.Factory() {
                 @Override
                 public <T> Index.Builder<T> create(Class<T> type) {
@@ -102,7 +102,7 @@ public class IndexFactoryProvider implements Provider<Index.Factory>
         try {
             log.info("DB schema initializing");
             _baseSchemaFactory.create()
-                .withTableNameFormat(_tableNameFormat) //TODO: Add prefix support
+                .withTableNameFormat(_tableNameFormat)
                 .withEndpoint(_endpoint)
                 .withCredProvider(() -> _creds)
                 .build()

--- a/src/main/java/com/distelli/europa/guice/IndexFactoryProvider.java
+++ b/src/main/java/com/distelli/europa/guice/IndexFactoryProvider.java
@@ -15,8 +15,6 @@ import com.distelli.persistence.IndexDescription;
 import com.distelli.persistence.Schema;
 import com.distelli.persistence.TableDescription;
 import java.net.URI;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Set;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -44,23 +42,10 @@ public class IndexFactoryProvider implements Provider<Index.Factory>
     private boolean _init = false;
     private Throwable _initFailure = null;
     private Index.Factory _indexFactory;
-    private float _scaleFactor;
 
-    public IndexFactoryProvider(URI defaultEndpoint, CredPair defaultCreds) {
-        this(defaultEndpoint, defaultCreds, null, 1.0f);
-    }
-
-    public IndexFactoryProvider(URI defaultEndpoint, CredPair defaultCreds, String dbPrefix) {
-        this(defaultEndpoint, defaultCreds, dbPrefix, 1.0f);
-    }
-
-    public IndexFactoryProvider(URI defaultEndpoint, CredPair defaultCreds, float scaleFactor) {
-        this(defaultEndpoint, defaultCreds, null, scaleFactor);
-    }
-
-    public IndexFactoryProvider(URI defaultEndpoint, CredPair defaultCreds, String dbPrefix, float scaleFactor)
+    // IndexFactoryProvider should only be used by EuropaInjectorModule
+    protected IndexFactoryProvider(URI defaultEndpoint, CredPair defaultCreds, String dbPrefix)
     {
-        _scaleFactor = scaleFactor;
         _endpoint = defaultEndpoint;
         _creds = defaultCreds;
         _tableNameFormat = (null == dbPrefix) ? "%s.europa" : (dbPrefix.replace("%", "%%") + "-%s.europa");


### PR DESCRIPTION
This adds an environment variable configuration `EUROPA_DB_PREFIX`, the value
of which is prepended to the database table names before they are created.