### PR TITLE
Log4j adjustments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM openjdk:8
 ADD target/dependency/*.jar target/*.jar /europa-85fac6ec/lib/
 ADD run /europa-85fac6ec/run
 ADD public /europa-85fac6ec/public
+ADD log4j-console-only.properties /europa-85fac6ec/log4j-console-only.properties
 
 EXPOSE 80
 EXPOSE 443

--- a/log4j-console-file.properties
+++ b/log4j-console-file.properties
@@ -1,0 +1,25 @@
+# Define the types of logger and level of logging
+log4j.rootLogger=INFO,console,file
+log4j.com.distelli.europa.registry=DEBUG
+
+# Extra examples - uncomment as needed
+#log4j.com.distelli.europa=DEBUG
+#log4j.com.distelli.webserver=DEBUG
+#log4j.com.distelli.gcr=DEBUG
+#log4j.com.distelli.gcr=DEBUG
+#log4j.com.distelli.europa.monitor=DEBUG
+#log4j.com.distelli.persistence=DEBUG
+
+# Define Console Appender
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss.S z}:[%p]:[%t]:%c:%m%n
+
+# Define the File appender
+log4j.appender.file=org.apache.log4j.rolling.RollingFileAppender
+log4j.appender.file.File=logs/Europa.log
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss.S z}:[%p]:[%t]:%c:%m%n
+log4j.appender.file.RollingPolicy=org.apache.log4j.rolling.TimeBasedRollingPolicy
+log4j.appender.file.RollingPolicy.FileNamePattern=logs/Europa.%d{yyyy-MM-dd-HH}.log.gz
+log4j.appender.file.RollingPolicy.ActiveFileName=logs/Europa.log

--- a/log4j-console-only.properties
+++ b/log4j-console-only.properties
@@ -1,5 +1,5 @@
 # Define the types of logger and level of logging
-log4j.rootLogger=INFO,console,file
+log4j.rootLogger=INFO,console
 log4j.com.distelli.europa.registry=DEBUG
 
 # Extra examples - uncomment as needed
@@ -14,12 +14,3 @@ log4j.com.distelli.europa.registry=DEBUG
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss.S z}:[%p]:[%t]:%c:%m%n
-
-# Define the File appender
-log4j.appender.file=org.apache.log4j.rolling.RollingFileAppender
-log4j.appender.file.File=logs/Europa.log
-log4j.appender.file.layout=org.apache.log4j.PatternLayout
-log4j.appender.file.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss.S z}:[%p]:[%t]:%c:%m%n
-log4j.appender.file.RollingPolicy=org.apache.log4j.rolling.TimeBasedRollingPolicy
-log4j.appender.file.RollingPolicy.FileNamePattern=logs/Europa.log.%d{yyyy-MM-dd-HH}.log.gz
-log4j.appender.file.RollingPolicy.ActiveFileName=logs/Europa.log

--- a/log4j.properties
+++ b/log4j.properties
@@ -1,0 +1,25 @@
+# Define the types of logger and level of logging
+log4j.rootLogger=INFO,console,file
+log4j.com.distelli.europa.registry=DEBUG
+
+# Extra examples - uncomment as needed
+#log4j.com.distelli.europa=DEBUG
+#log4j.com.distelli.webserver=DEBUG
+#log4j.com.distelli.gcr=DEBUG
+#log4j.com.distelli.gcr=DEBUG
+#log4j.com.distelli.europa.monitor=DEBUG
+#log4j.com.distelli.persistence=DEBUG
+
+# Define Console Appender
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss.S z}:[%p]:[%t]:%c:%m%n
+
+# Define the File appender
+log4j.appender.file=org.apache.log4j.rolling.RollingFileAppender
+log4j.appender.file.File=logs/Europa.log
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss.S z}:[%p]:[%t]:%c:%m%n
+log4j.appender.file.RollingPolicy=org.apache.log4j.rolling.TimeBasedRollingPolicy
+log4j.appender.file.RollingPolicy.FileNamePattern=logs/Europa.log.%d{yyyy-MM-dd-HH}.log.gz
+log4j.appender.file.RollingPolicy.ActiveFileName=logs/Europa.log

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
     <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
-      <version>1.2.16</version>
+      <version>1.2.17</version>
     </dependency>
 
     <dependency>
@@ -169,7 +169,7 @@
     <dependency>
       <groupId>log4j</groupId>
       <artifactId>apache-log4j-extras</artifactId>
-      <version>1.1</version>
+      <version>1.2.17</version>
       <scope>compile</scope>
     </dependency>
 

--- a/run
+++ b/run
@@ -2,5 +2,5 @@
 
 JAVA_HOME=/usr
 CLASSPATH="$(find /europa-85fac6ec/lib/ -name '*.jar' | xargs echo | tr ' ' ':')"
-JVM_ARGS="-Duser.timezone=UTC -Xmx2000M -Xms2000M"
-exec $JAVA_HOME/bin/java $JVM_ARGS -cp $CLASSPATH com.distelli.europa.Europa --stage prod --port 80 --ssl-port 443 --log-to-console $@
+JVM_ARGS="-Duser.timezone=UTC -Xmx2000M -Xms2000M -Dlog4j.configuration=file:$(pwd)/log4j-console-only.properties"
+exec $JAVA_HOME/bin/java $JVM_ARGS -cp $CLASSPATH com.distelli.europa.Europa --stage prod --port 80 --ssl-port 443 $@

--- a/run.sh
+++ b/run.sh
@@ -7,5 +7,5 @@ fi
 export STAGE=beta
 DEPS_CLASSPATH=`cat target/.classpath`
 CLASSPATH=target/classes/:$DEPS_CLASSPATH
-JVM_ARGS="-Duser.timezone=UTC -Xmx2000M -Xms2000M"
+JVM_ARGS="-Duser.timezone=UTC -Xmx2000M -Xms2000M -Dlog4j.configuration=file:$(pwd)/log4j.properties"
 $JAVA_HOME/bin/java $JVM_ARGS -cp $CLASSPATH com.distelli.europa.Europa --stage beta --port 5050 --ssl-port 5443 --log-to-console --config "$EUROPA_CONFIG" $@

--- a/run.sh
+++ b/run.sh
@@ -7,5 +7,5 @@ fi
 export STAGE=beta
 DEPS_CLASSPATH=`cat target/.classpath`
 CLASSPATH=target/classes/:$DEPS_CLASSPATH
-JVM_ARGS="-Duser.timezone=UTC -Xmx2000M -Xms2000M -Dlog4j.configuration=file:$(pwd)/log4j.properties"
-$JAVA_HOME/bin/java $JVM_ARGS -cp $CLASSPATH com.distelli.europa.Europa --stage beta --port 5050 --ssl-port 5443 --log-to-console --config "$EUROPA_CONFIG" $@
+JVM_ARGS="-Duser.timezone=UTC -Xmx2000M -Xms2000M -Dlog4j.configuration=file:$(pwd)/log4j-console-only.properties"
+$JAVA_HOME/bin/java $JVM_ARGS -cp $CLASSPATH com.distelli.europa.Europa --stage beta --port 5050 --ssl-port 5443 --config "$EUROPA_CONFIG" $@

--- a/src/main/java/com/distelli/europa/Europa.java
+++ b/src/main/java/com/distelli/europa/Europa.java
@@ -8,49 +8,31 @@
 */
 package com.distelli.europa;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.util.HashSet;
-import java.util.Set;
-import javax.inject.Inject;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import com.distelli.europa.filters.ForceHttpsFilter;
-import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.handler.ErrorHandler;
-import org.eclipse.jetty.servlet.DefaultServlet;
-import org.eclipse.jetty.servlet.ServletHolder;
 import com.distelli.europa.EuropaConfiguration.EuropaStage;
-import com.distelli.europa.db.RegistryBlobDb;
-import com.distelli.europa.db.TokenAuthDb;
-import com.distelli.europa.filters.StorageInitFilter;
+import com.distelli.europa.filters.ForceHttpsFilter;
 import com.distelli.europa.filters.RegistryAuthFilter;
-import com.distelli.europa.guice.*;
+import com.distelli.europa.filters.StorageInitFilter;
+import com.distelli.europa.guice.AjaxHelperModule;
+import com.distelli.europa.guice.EuropaInjectorModule;
 import com.distelli.europa.handlers.StaticContentErrorHandler;
 import com.distelli.europa.monitor.DispatchRepoMonitorTasks;
-import com.distelli.europa.util.*;
+import com.distelli.europa.util.CmdLineArgs;
 import com.distelli.objectStore.impl.ObjectStoreModule;
 import com.distelli.persistence.impl.PersistenceModule;
-import com.distelli.utils.Log4JConfigurator;
-import com.distelli.europa.db.TokenAuthDb;
-import com.distelli.europa.db.RegistryBlobDb;
-import com.distelli.europa.db.SequenceDb;
-import com.distelli.europa.db.ContainerRepoDb;
-import com.distelli.europa.db.RegistryCredsDb;
-import com.distelli.europa.db.NotificationsDb;
-import com.distelli.europa.db.RepoEventsDb;
-import com.distelli.europa.db.RegistryManifestDb;
 import com.distelli.webserver.*;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import com.google.inject.Provides;
 import com.google.inject.Stage;
-import java.util.Arrays;
 import lombok.extern.log4j.Log4j;
-import java.util.List;
+import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
+
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
 
 @Log4j
 public class Europa
@@ -77,24 +59,11 @@ public class Europa
     public Europa(String[] args)
     {
         _cmdLineArgs = new CmdLineArgs(args);
-        boolean logToConsole = _cmdLineArgs.hasOption(Constants.LOG_TO_CONSOLE_ARG);
         // Initialize Logging
         File logsDir = new File("./logs/");
         if(!logsDir.exists())
             logsDir.mkdirs();
 
-        if(logToConsole)
-            Log4JConfigurator.configure(true);
-        else
-            Log4JConfigurator.configure(logsDir, "Europa");
-        Log4JConfigurator.setLogLevel("INFO");
-        Log4JConfigurator.setLogLevel("com.distelli.europa.registry", "DEBUG");
-        //Log4JConfigurator.setLogLevel("com.distelli.europa", "DEBUG");
-        //Log4JConfigurator.setLogLevel("com.distelli.webserver", "ERROR");
-        //Log4JConfigurator.setLogLevel("com.distelli.gcr", "ERROR");
-        //Log4JConfigurator.setLogLevel("com.distelli.europa.monitor", "DEBUG");
-        //Log4JConfigurator.setLogLevel("com.distelli.webserver", "DEBUG");
-        //Log4JConfigurator.setLogLevel("com.distelli.persistence", "DEBUG");
         _configFilePath = _cmdLineArgs.getOption("config");
         String portStr = _cmdLineArgs.getOption("port");
         if(portStr != null)


### PR DESCRIPTION
This changes how log4j is configured for PCR - this allows for a
log4j.properties file to be configured to allow for changing log levels
without needing to recompile.  Also clicked "Optimized imports" in my IDE to clean
up the unused ones.

Tested by both having a local version running in DEBUG with `log4j.appender.file.RollingPolicy.FileNamePattern=logs/Europa.%d{yyyy-MM-dd-HH-mm}.log.gz`, to make it rotate every minute, and by building the docker image and running it locally to confirm output is still going to console.  Files rotate as expected, and console output is the same as before.

This should mirror the old configuration of the Log4JConfigurator, and keeps in place the commented out lines so users can see some examples of items that are logging.