### PR TITLE
Move logdir creation to bash script

### DIFF
--- a/log4j-console-only.properties
+++ b/log4j-console-only.properties
@@ -6,7 +6,6 @@ log4j.com.distelli.europa.registry=DEBUG
 #log4j.com.distelli.europa=DEBUG
 #log4j.com.distelli.webserver=DEBUG
 #log4j.com.distelli.gcr=DEBUG
-#log4j.com.distelli.gcr=DEBUG
 #log4j.com.distelli.europa.monitor=DEBUG
 #log4j.com.distelli.persistence=DEBUG
 

--- a/log4j-file-only.properties
+++ b/log4j-file-only.properties
@@ -1,5 +1,5 @@
 # Define the types of logger and level of logging
-log4j.rootLogger=INFO,console,file
+log4j.rootLogger=INFO,file
 log4j.com.distelli.europa.registry=DEBUG
 
 # Extra examples - uncomment as needed
@@ -8,11 +8,6 @@ log4j.com.distelli.europa.registry=DEBUG
 #log4j.com.distelli.gcr=DEBUG
 #log4j.com.distelli.europa.monitor=DEBUG
 #log4j.com.distelli.persistence=DEBUG
-
-# Define Console Appender
-log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss.S z}:[%p]:[%t]:%c:%m%n
 
 # Define the File appender
 log4j.appender.file=org.apache.log4j.rolling.RollingFileAppender

--- a/run.sh
+++ b/run.sh
@@ -4,8 +4,15 @@ if [ -z "$EUROPA_CONFIG" ]; then
     EUROPA_CONFIG=EuropaConfig.json
 fi
 
+if [ -z "$EUROPA_ENABLE_LOGS" ]; then
+    DLOG4J_CONFIG="$(pwd)/log4j-console-only.properties"
+else
+    DLOG4J_CONFIG="$(pwd)/log4j-console-file.properties"; mkdir -p logs;
+fi
+
 export STAGE=beta
 DEPS_CLASSPATH=`cat target/.classpath`
 CLASSPATH=target/classes/:$DEPS_CLASSPATH
-JVM_ARGS="-Duser.timezone=UTC -Xmx2000M -Xms2000M -Dlog4j.configuration=file:$(pwd)/log4j-console-only.properties"
+
+JVM_ARGS="-Duser.timezone=UTC -Xmx2000M -Xms2000M -Dlog4j.configuration=file:${DLOG4J_CONFIG}"
 $JAVA_HOME/bin/java $JVM_ARGS -cp $CLASSPATH com.distelli.europa.Europa --stage beta --port 5050 --ssl-port 5443 --config "$EUROPA_CONFIG" $@

--- a/src/main/java/com/distelli/europa/Europa.java
+++ b/src/main/java/com/distelli/europa/Europa.java
@@ -71,11 +71,7 @@ public class Europa
     public Europa(String[] args)
     {
         _cmdLineArgs = new CmdLineArgs(args);
-        // Initialize Logging
-        File logsDir = new File("./logs/");
-        if(!logsDir.exists())
-            logsDir.mkdirs();
-
+        
         _configFilePath = _cmdLineArgs.getOption("config");
         String portStr = _cmdLineArgs.getOption("port");
         if(portStr != null)


### PR DESCRIPTION
We now only make a log directory if the word "file" is in the log4
properties file, as if we're just using console logging, it's not
needed.