### PR TITLE
Ignore Docker Hub test

### DIFF
--- a/src/test/java/com/distelli/europa/clients/TestDockerHubClient.java
+++ b/src/test/java/com/distelli/europa/clients/TestDockerHubClient.java
@@ -1,5 +1,6 @@
 package com.distelli.europa.clients;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.Before;
 import javax.inject.Inject;
@@ -23,6 +24,7 @@ public class TestDockerHubClient {
         Guice.createInjector(new EuropaTestModule())
             .injectMembers(this);
     }
+    @Ignore("replace with a test that actually tests something")
     @Test
     public void testListRepositories() throws Exception {
         DockerHubClient client = _dhClientBuilderProvider.get()


### PR DESCRIPTION
TestDockerHubClient doesn't actually have any test cases in it, and it can be
somewhat fragile, so this marks it @Ignore and notes that it should be replaced
later on.