### PR TITLE
(WHO-1182) Add PCManualPromotionGate class

### DIFF
--- a/src/main/java/com/distelli/europa/ajax/AddPipelineComponent.java
+++ b/src/main/java/com/distelli/europa/ajax/AddPipelineComponent.java
@@ -1,28 +1,20 @@
 package com.distelli.europa.ajax;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import javax.inject.Inject;
-
-import com.distelli.europa.clients.*;
-import com.distelli.europa.db.*;
-import com.distelli.europa.models.*;
-import com.distelli.gcr.*;
-import com.distelli.gcr.auth.*;
-import com.distelli.gcr.models.*;
-import com.distelli.persistence.*;
-import com.distelli.webserver.*;
-import com.distelli.europa.models.PipelineComponent;
-import com.distelli.europa.models.PCCopyToRepository;
-import com.google.inject.Singleton;
-import org.eclipse.jetty.http.HttpMethod;
-import lombok.extern.log4j.Log4j;
-import javax.inject.Inject;
 import com.distelli.europa.EuropaRequestContext;
+import com.distelli.europa.db.PipelineDb;
+import com.distelli.europa.models.PCCopyToRepository;
+import com.distelli.europa.models.PCManualPromotionGate;
+import com.distelli.europa.models.PipelineComponent;
 import com.distelli.europa.util.PermissionCheck;
-import java.util.Map;
+import com.distelli.webserver.AjaxHelper;
+import com.distelli.webserver.AjaxRequest;
+import com.distelli.webserver.HTTPMethod;
+import com.google.inject.Singleton;
+import lombok.extern.log4j.Log4j;
+
+import javax.inject.Inject;
 import java.util.HashMap;
+import java.util.Map;
 
 @Log4j
 @Singleton
@@ -31,6 +23,7 @@ public class AddPipelineComponent extends AjaxHelper<EuropaRequestContext>
     private static final Map<String, Class<? extends PipelineComponent>> TYPES = new HashMap<>();
     static {
         TYPES.put("CopyToRepository", PCCopyToRepository.class);
+        TYPES.put("ManualPromotionGate", PCManualPromotionGate.class);
     }
 
     @Inject

--- a/src/main/java/com/distelli/europa/ajax/AjaxErrors.java
+++ b/src/main/java/com/distelli/europa/ajax/AjaxErrors.java
@@ -18,6 +18,7 @@ public class AjaxErrors
         public static final String PipelineNotFound = "PipelineNotFound";
         public static final String BadRepoName = "BadRepoName";
         public static final String BadPipelineName = "BadPipelineName";
+        public static final String BadPipelineComponent = "BadPipelineComponent";
         public static final String BadS3Credentials = "BadS3Credentials";
         public static final String BadS3Bucket = "BadS3Bucket";
         public static final String BadS3Settings = "BadS3Settings";

--- a/src/main/java/com/distelli/europa/ajax/RunPipelineManualPromotion.java
+++ b/src/main/java/com/distelli/europa/ajax/RunPipelineManualPromotion.java
@@ -18,6 +18,7 @@ import com.distelli.webserver.AjaxRequest;
 import javax.inject.Inject;
 import java.util.List;
 import java.util.OptionalInt;
+import java.util.stream.IntStream;
 
 public class RunPipelineManualPromotion extends AjaxHelper<EuropaRequestContext> {
     @Inject
@@ -69,20 +70,15 @@ public class RunPipelineManualPromotion extends AjaxHelper<EuropaRequestContext>
     }
 
     protected List<PipelineComponent> getComponentsToRun(Pipeline pipeline, String componentId) {
-        OptionalInt componentIndex = OptionalInt.empty();
-
-        for (int i = 0; i < pipeline.getComponents().size(); i++) {
-            if (pipeline.getComponents().get(i).getId().equalsIgnoreCase(componentId)) {
-                componentIndex = OptionalInt.of(i);
-                break;
-            }
-        }
+        List<PipelineComponent> components = pipeline.getComponents();
+        OptionalInt componentIndex = IntStream.range(0, components.size())
+            .filter((i) -> componentId.equalsIgnoreCase(components.get(i).getId()))
+            .findFirst();
         if (!componentIndex.isPresent()) {
             throw(new AjaxClientException("The specified PipelineComponent is not in the specified Pipeline",
                                           AjaxErrors.Codes.BadPipelineComponent, 400));
         }
-        return pipeline.getComponents().subList(componentIndex.getAsInt(),
-                                                pipeline.getComponents().size());
+        return components.subList(componentIndex.getAsInt(), components.size());
 
     }
 }

--- a/src/main/java/com/distelli/europa/ajax/RunPipelineManualPromotion.java
+++ b/src/main/java/com/distelli/europa/ajax/RunPipelineManualPromotion.java
@@ -1,0 +1,88 @@
+package com.distelli.europa.ajax;
+
+import com.distelli.europa.EuropaRequestContext;
+import com.distelli.europa.db.ContainerRepoDb;
+import com.distelli.europa.db.PipelineDb;
+import com.distelli.europa.db.RegistryManifestDb;
+import com.distelli.europa.models.ContainerRepo;
+import com.distelli.europa.models.PCCopyToRepository;
+import com.distelli.europa.models.Pipeline;
+import com.distelli.europa.models.PipelineComponent;
+import com.distelli.europa.models.RegistryManifest;
+import com.distelli.europa.pipeline.RunPipeline;
+import com.distelli.europa.util.PermissionCheck;
+import com.distelli.webserver.AjaxClientException;
+import com.distelli.webserver.AjaxHelper;
+import com.distelli.webserver.AjaxRequest;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.OptionalInt;
+
+public class RunPipelineManualPromotion extends AjaxHelper<EuropaRequestContext> {
+    @Inject
+    protected PermissionCheck _permissionCheck;
+    @Inject
+    private ContainerRepoDb _repoDb;
+    @Inject
+    private PipelineDb _pipelineDb;
+    @Inject
+    private RegistryManifestDb _manifestDb;
+    @Inject
+    private RunPipeline _runPipeline;
+
+    @Override
+    public Object get(AjaxRequest ajaxRequest, EuropaRequestContext requestContext) {
+        String pipelineId = ajaxRequest.getParam("pipelineId", true);
+        String componentId = ajaxRequest.getParam("componentId", true);
+        String sourceRepoId = ajaxRequest.getParam("sourceRepoId", true);
+        String sourceTag = ajaxRequest.getParam("sourceTag", true);
+        String destinationTag = ajaxRequest.getParam("destinationTag", true);
+
+        _permissionCheck.check(ajaxRequest.getOperation(), requestContext, pipelineId);
+
+        String domain = requestContext.getOwnerDomain();
+        Pipeline pipeline = _pipelineDb.getPipeline(pipelineId);
+        ContainerRepo sourceRepo = _repoDb.getRepo(domain, sourceRepoId);
+        RegistryManifest manifest = _manifestDb.getManifestByRepoIdTag(domain, sourceRepoId, sourceTag);
+        String manifestId = (manifest == null) ? null : manifest.getManifestId();
+
+        if (pipeline == null) {
+            throw(new AjaxClientException("The specified Pipeline was not found",
+                                          AjaxErrors.Codes.PipelineNotFound, 404));
+        }
+        if (sourceRepo == null) {
+            throw(new AjaxClientException("The specified source repo was not found",
+                                          AjaxErrors.Codes.RepoNotFound, 404));
+        }
+
+        List<PipelineComponent> componentsToRun = getComponentsToRun(pipeline, componentId);
+
+        // Configure the destinationTag where appropriate
+        if ((destinationTag != null) && (componentsToRun.get(0) instanceof PCCopyToRepository)) {
+            ((PCCopyToRepository) componentsToRun.get(0)).setTag(destinationTag);
+        }
+
+        _runPipeline.runPipeline(componentsToRun, sourceRepo, sourceTag, manifestId);
+
+        return _pipelineDb.getPipeline(pipelineId);
+    }
+
+    protected List<PipelineComponent> getComponentsToRun(Pipeline pipeline, String componentId) {
+        OptionalInt componentIndex = OptionalInt.empty();
+
+        for (int i = 0; i < pipeline.getComponents().size(); i++) {
+            if (pipeline.getComponents().get(i).getId().equalsIgnoreCase(componentId)) {
+                componentIndex = OptionalInt.of(i);
+                break;
+            }
+        }
+        if (!componentIndex.isPresent()) {
+            throw(new AjaxClientException("The specified PipelineComponent is not in the specified Pipeline",
+                                          AjaxErrors.Codes.BadPipelineComponent, 400));
+        }
+        return pipeline.getComponents().subList(componentIndex.getAsInt(),
+                                                pipeline.getComponents().size());
+
+    }
+}

--- a/src/main/java/com/distelli/europa/db/PipelineDb.java
+++ b/src/main/java/com/distelli/europa/db/PipelineDb.java
@@ -1,20 +1,11 @@
 package com.distelli.europa.db;
 
-import lombok.extern.log4j.Log4j;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.Collections;
-import javax.inject.Singleton;
-import javax.inject.Inject;
-import java.util.TreeSet;
-import java.util.Arrays;
-import java.util.List;
-import java.util.ArrayList;
 import com.distelli.europa.models.ExecutionStatus;
+import com.distelli.europa.models.PCCopyToRepository;
+import com.distelli.europa.models.PCManualPromotionGate;
 import com.distelli.europa.models.Pipeline;
 import com.distelli.europa.models.PipelineComponent;
-import com.distelli.europa.models.PCCopyToRepository;
-import com.distelli.persistence.AttrDescription;
+import com.distelli.jackson.transform.TransformModule;
 import com.distelli.persistence.AttrType;
 import com.distelli.persistence.ConvertMarker;
 import com.distelli.persistence.Index;
@@ -22,14 +13,23 @@ import com.distelli.persistence.IndexDescription;
 import com.distelli.persistence.IndexType;
 import com.distelli.persistence.PageIterator;
 import com.distelli.persistence.TableDescription;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.distelli.jackson.transform.TransformModule;
 import com.distelli.utils.CompactUUID;
-import java.util.stream.Collectors;
-import javax.persistence.RollbackException;
-import javax.persistence.EntityNotFoundException;
-import java.lang.reflect.InvocationTargetException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.log4j.Log4j;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.persistence.EntityNotFoundException;
+import javax.persistence.RollbackException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 @Log4j
 @Singleton
@@ -46,7 +46,8 @@ public class PipelineDb extends BaseDb
 
     private static final List<Class<? extends PipelineComponent>> PIPELINE_COMPONENT_TYPES = Arrays.asList(
         // NOTE: Order matters! Always add new elements to the end!
-        PCCopyToRepository.class);
+        PCCopyToRepository.class,
+        PCManualPromotionGate.class);
 
     // The indexes contain pipeline items, since some things
     // in the index are pipeline objects and other things are

--- a/src/main/java/com/distelli/europa/guice/AjaxHelperModule.java
+++ b/src/main/java/com/distelli/europa/guice/AjaxHelperModule.java
@@ -8,16 +8,56 @@
 */
 package com.distelli.europa.guice;
 
+import com.distelli.europa.ajax.AddPipelineComponent;
+import com.distelli.europa.ajax.CreateAuthToken;
+import com.distelli.europa.ajax.CreateLocalRepo;
+import com.distelli.europa.ajax.DeleteAuthToken;
+import com.distelli.europa.ajax.DeleteContainerRepo;
+import com.distelli.europa.ajax.DeletePipelineContainerRepoId;
+import com.distelli.europa.ajax.DeleteRegistryCreds;
+import com.distelli.europa.ajax.DeleteRepoNotification;
+import com.distelli.europa.ajax.GetContainerRepo;
+import com.distelli.europa.ajax.GetNotificationRecord;
+import com.distelli.europa.ajax.GetPipeline;
+import com.distelli.europa.ajax.GetRegionsForProvider;
+import com.distelli.europa.ajax.GetRepoOverview;
+import com.distelli.europa.ajax.GetSslSettings;
+import com.distelli.europa.ajax.GetStorageSettings;
+import com.distelli.europa.ajax.ListAuthTokens;
+import com.distelli.europa.ajax.ListContainerRepos;
+import com.distelli.europa.ajax.ListPipelines;
+import com.distelli.europa.ajax.ListRegistryCreds;
+import com.distelli.europa.ajax.ListRepoEvents;
+import com.distelli.europa.ajax.ListRepoManifests;
+import com.distelli.europa.ajax.ListRepoNotifications;
+import com.distelli.europa.ajax.ListReposInRegistry;
+import com.distelli.europa.ajax.MovePipelineComponent;
+import com.distelli.europa.ajax.NewPipeline;
+import com.distelli.europa.ajax.RedeliverWebhook;
+import com.distelli.europa.ajax.RemovePipeline;
+import com.distelli.europa.ajax.RemovePipelineComponent;
+import com.distelli.europa.ajax.RunPipelineManualPromotion;
+import com.distelli.europa.ajax.SaveContainerRepo;
+import com.distelli.europa.ajax.SaveGcrServiceAccountCreds;
+import com.distelli.europa.ajax.SaveRegistryCreds;
+import com.distelli.europa.ajax.SaveRepoNotification;
+import com.distelli.europa.ajax.SaveRepoOverview;
+import com.distelli.europa.ajax.SaveSslSettings;
+import com.distelli.europa.ajax.SaveStorageSettings;
+import com.distelli.europa.ajax.SetAuthTokenStatus;
+import com.distelli.europa.ajax.SetPipelineContainerRepoId;
+import com.distelli.europa.ajax.SetRepoPublic;
+import com.distelli.europa.ajax.TestWebhookDelivery;
+import com.distelli.europa.ajax.UpdateStorageCreds;
+import com.distelli.webserver.AjaxHelper;
+import com.distelli.webserver.AjaxHelperMap;
+import com.google.inject.AbstractModule;
+import com.google.inject.TypeLiteral;
+import com.google.inject.multibindings.MapBinder;
+import lombok.extern.log4j.Log4j;
+
 import java.util.HashSet;
 import java.util.Set;
-
-import com.distelli.europa.ajax.*;
-import com.distelli.webserver.*;
-import com.google.inject.TypeLiteral;
-import com.google.inject.AbstractModule;
-import com.google.inject.multibindings.MapBinder;
-
-import lombok.extern.log4j.Log4j;
 
 @Log4j
 public class AjaxHelperModule extends AbstractModule
@@ -39,6 +79,7 @@ public class AjaxHelperModule extends AbstractModule
         addBinding(AddPipelineComponent.class);
         addBinding(MovePipelineComponent.class);
         addBinding(RemovePipelineComponent.class);
+        addBinding(RunPipelineManualPromotion.class);
 
         addBinding(GetRegionsForProvider.class);
         addBinding(ListReposInRegistry.class);

--- a/src/main/java/com/distelli/europa/models/PCCopyToRepository.java
+++ b/src/main/java/com/distelli/europa/models/PCCopyToRepository.java
@@ -1,57 +1,55 @@
 package com.distelli.europa.models;
 
-import lombok.Data;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
-import lombok.AllArgsConstructor;
-import lombok.Singular;
-import javax.inject.Inject;
-import com.distelli.europa.db.RegistryManifestDb;
+import com.distelli.europa.clients.ECRClient;
 import com.distelli.europa.db.ContainerRepoDb;
+import com.distelli.europa.db.RegistryBlobDb;
+import com.distelli.europa.db.RegistryCredsDb;
+import com.distelli.europa.db.RegistryManifestDb;
 import com.distelli.europa.db.RepoEventsDb;
-import lombok.extern.log4j.Log4j;
-import java.util.Collections;
-import com.distelli.webserver.AjaxClientException;
-import com.distelli.webserver.JsonError;
-import javax.inject.Provider;
+import com.distelli.europa.util.ObjectKeyFactory;
 import com.distelli.gcr.GcrClient;
 import com.distelli.gcr.GcrRegion;
-import com.distelli.gcr.exceptions.GcrException;
-import com.distelli.gcr.models.GcrManifestV2Schema1;
-import com.distelli.gcr.models.GcrManifestMeta;
-import com.distelli.gcr.models.GcrManifest;
-import com.distelli.gcr.models.GcrBlobUpload;
-import com.distelli.gcr.models.GcrBlobReader;
-import com.distelli.gcr.models.GcrBlobMeta;
 import com.distelli.gcr.auth.GcrCredentials;
 import com.distelli.gcr.auth.GcrServiceAccountCredentials;
-import com.distelli.europa.db.RegistryCredsDb;
-import com.distelli.europa.db.RegistryBlobDb;
-import com.distelli.europa.clients.ECRClient;
-import java.net.URI;
-import java.io.IOException;
-import java.io.InputStream;
-import com.distelli.objectStore.ObjectStore;
+import com.distelli.gcr.models.GcrBlobMeta;
+import com.distelli.gcr.models.GcrBlobReader;
+import com.distelli.gcr.models.GcrBlobUpload;
+import com.distelli.gcr.models.GcrManifest;
+import com.distelli.gcr.models.GcrManifestMeta;
 import com.distelli.objectStore.ObjectKey;
-import com.distelli.europa.util.ObjectKeyFactory;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static com.distelli.europa.Constants.DOMAIN_ZERO;
-import java.util.List;
-import java.util.ArrayList;
-import java.io.ByteArrayInputStream;
+import com.distelli.objectStore.ObjectStore;
 import com.distelli.utils.CountingInputStream;
 import com.distelli.utils.ResettableInputStream;
-import java.security.MessageDigest;
-import java.security.DigestInputStream;
-import static javax.xml.bind.DatatypeConverter.printHexBinary;
+import com.distelli.webserver.AjaxClientException;
+import com.distelli.webserver.JsonError;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.log4j.Log4j;
 import okhttp3.ConnectionPool;
+import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
-import okhttp3.HttpUrl;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.util.ArrayList;
 import java.util.Base64;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Collections;
+import java.util.List;
+
+import static com.distelli.europa.Constants.DOMAIN_ZERO;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static javax.xml.bind.DatatypeConverter.printHexBinary;
 
 /**
  * Pipeline component that copies from one repository to another.
@@ -88,7 +86,7 @@ public class PCCopyToRepository extends PipelineComponent {
     private ConnectionPool _connectionPool;
 
     @Override
-    public boolean execute(ContainerRepo srcRepo, String srcTag, String manifestDigestSha) throws Exception {
+    public boolean execute(ContainerRepo srcRepo, String srcTag, String manifestDigestSha, String destinationTag) throws Exception {
         if ( null == _repoDb || null == _manifestDb ) {
             throw new IllegalStateException("Injector.injectMembers(this) has not been called");
         }
@@ -99,7 +97,7 @@ public class PCCopyToRepository extends PipelineComponent {
             throw new IllegalStateException("Tag must not be null");
         }
         // Not configured? Ignore...
-        if ( null == destinationContainerRepoId || 
+        if ( null == destinationContainerRepoId ||
              null == destinationContainerRepoDomain )
         {
             log.error("PipelineComponentId="+getId()+" has null destinationContainerRepoId or destinationContainerRepoDomain");
@@ -125,6 +123,15 @@ public class PCCopyToRepository extends PipelineComponent {
                       destinationContainerRepoId);
             return true;
         }
+
+        if ( null == tag ) {
+            if ( null == destinationTag ) {
+                destinationTag = srcTag;
+            }
+        } else {
+            destinationTag = tag;
+        }
+
         if ( srcRepo.isLocal() && destRepo.isLocal() ) {
             // Optimization, simply update the DB:
             RegistryManifest manifest = _manifestDb.getManifestByRepoIdTag(
@@ -139,7 +146,7 @@ public class PCCopyToRepository extends PipelineComponent {
             RegistryManifest copy = manifest.toBuilder()
                 .domain(destRepo.getDomain())
                 .containerRepoId(destRepo.getId())
-                .tag(null == tag ? srcTag : tag)
+                .tag(destinationTag)
                 .build();
             _manifestDb.put(copy);
             RepoEvent event = RepoEvent.builder()
@@ -166,10 +173,8 @@ public class PCCopyToRepository extends PipelineComponent {
                 log.error("Manifest not found for repo="+srcRepo.getName()+" ref="+manifestDigestSha);
                 return true;
             }
-            String reference = tag;
-            if ( null == reference ) reference = srcTag;
 
-            genericCopy(manifest, srcRegistry, srcRepo.getName(), srcTag, crossRepositoryBlobMount, dstRegistry, destRepo.getName(),reference);
+            genericCopy(manifest, srcRegistry, srcRepo.getName(), srcTag, crossRepositoryBlobMount, dstRegistry, destRepo.getName(), destinationTag);
         }
         return true;
     }
@@ -353,22 +358,22 @@ public class PCCopyToRepository extends PipelineComponent {
         public GcrManifest getManifest(String repository, String reference) throws IOException {
             return client.getManifest(repository, reference, "application/vnd.docker.distribution.manifest.v2+json");
         }
-            
+
         @Override
         public <T> T getBlob(String repository, String digest, GcrBlobReader<T> reader) throws IOException {
             return client.getBlob(repository, digest, reader);
         }
-            
+
         @Override
         public GcrBlobUpload createBlobUpload(String repository, String digest, String fromRepository) throws IOException {
             return client.createBlobUpload(repository, digest, fromRepository);
         }
-            
+
         @Override
         public GcrBlobMeta blobUploadChunk(GcrBlobUpload blobUpload, InputStream chunk, Long chunkLength, String digest) throws IOException {
             return client.blobUploadChunk(blobUpload, chunk, chunkLength, digest);
         }
-            
+
         @Override
         public GcrManifestMeta putManifest(String repository, String reference, GcrManifest manifest) throws IOException {
             return client.putManifest(repository, reference, manifest);

--- a/src/main/java/com/distelli/europa/models/PCManualPromotionGate.java
+++ b/src/main/java/com/distelli/europa/models/PCManualPromotionGate.java
@@ -3,6 +3,8 @@ package com.distelli.europa.models;
 import lombok.Data;
 import lombok.extern.log4j.Log4j;
 
+import java.util.Optional;
+
 /**
  * Pipeline component representing a manual promotion gate
  */
@@ -10,15 +12,15 @@ import lombok.extern.log4j.Log4j;
 @Data
 public class PCManualPromotionGate extends PipelineComponent {
     /**
-     * Always returns {@code false}
+     * Always ends pipeline execution
      *
      * @param srcRepo Ignored
      * @param srcTag Ignored
      * @param manifestDigestSha Ignored
-     * @return Always {@code false}
+     * @return Always an empty Optional
      */
     @Override
-    public PipelineComponentResult execute(ContainerRepo srcRepo, String srcTag, String manifestDigestSha) {
-        return (new PipelineComponentResult(false, srcRepo, srcTag, manifestDigestSha));
+    public Optional<PromotedImage> execute(ContainerRepo srcRepo, String srcTag, String manifestDigestSha) {
+        return (Optional.empty());
     }
 }

--- a/src/main/java/com/distelli/europa/models/PCManualPromotionGate.java
+++ b/src/main/java/com/distelli/europa/models/PCManualPromotionGate.java
@@ -1,8 +1,6 @@
 package com.distelli.europa.models;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 import lombok.extern.log4j.Log4j;
 
 /**
@@ -10,50 +8,17 @@ import lombok.extern.log4j.Log4j;
  */
 @Log4j
 @Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class PCManualPromotionGate extends PipelineComponent {
     /**
-     * Set this to {@code true} to make this component execute successfully.
-     */
-    private boolean wasManuallyTriggered = false;
-
-    /**
-     * Returns {@code true} or {@code false} depending on whether the component was manually triggered.
+     * Always returns {@code false}
      *
      * @param srcRepo Ignored
      * @param srcTag Ignored
      * @param manifestDigestSha Ignored
-     * @param destinationTag Ignored
-     * @return {@code true} if this component was manually triggered, {@code false} otherwise
+     * @return Always {@code false}
      */
     @Override
-    public boolean execute(ContainerRepo srcRepo, String srcTag, String manifestDigestSha, String destinationTag) {
-        return wasManuallyTriggered;
-    }
-
-    protected PCManualPromotionGate(String id) {
-        super(id);
-    }
-
-    protected PCManualPromotionGate(String id, boolean wasManuallyTriggered) {
-        super(id);
-        this.wasManuallyTriggered = wasManuallyTriggered;
-    }
-
-    public static class Builder<T extends Builder<T>> extends PipelineComponent.Builder<T> {
-        protected boolean wasManuallyTriggered = false;
-
-        public T wasManuallyTriggered(boolean wasManuallyTriggered) {
-            this.wasManuallyTriggered = wasManuallyTriggered;
-            return self();
-        }
-        public PCManualPromotionGate build() {
-            return new PCManualPromotionGate(id, wasManuallyTriggered);
-        }
-    }
-
-    public static Builder<?> builder() {
-        return new Builder();
+    public PipelineComponentResult execute(ContainerRepo srcRepo, String srcTag, String manifestDigestSha) {
+        return (new PipelineComponentResult(false, srcRepo, srcTag, manifestDigestSha));
     }
 }

--- a/src/main/java/com/distelli/europa/models/PCManualPromotionGate.java
+++ b/src/main/java/com/distelli/europa/models/PCManualPromotionGate.java
@@ -1,0 +1,59 @@
+package com.distelli.europa.models;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.log4j.Log4j;
+
+/**
+ * Pipeline component representing a manual promotion gate
+ */
+@Log4j
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PCManualPromotionGate extends PipelineComponent {
+    /**
+     * Set this to {@code true} to make this component execute successfully.
+     */
+    private boolean wasManuallyTriggered = false;
+
+    /**
+     * Returns {@code true} or {@code false} depending on whether the component was manually triggered.
+     *
+     * @param srcRepo Ignored
+     * @param srcTag Ignored
+     * @param manifestDigestSha Ignored
+     * @param destinationTag Ignored
+     * @return {@code true} if this component was manually triggered, {@code false} otherwise
+     */
+    @Override
+    public boolean execute(ContainerRepo srcRepo, String srcTag, String manifestDigestSha, String destinationTag) {
+        return wasManuallyTriggered;
+    }
+
+    protected PCManualPromotionGate(String id) {
+        super(id);
+    }
+
+    protected PCManualPromotionGate(String id, boolean wasManuallyTriggered) {
+        super(id);
+        this.wasManuallyTriggered = wasManuallyTriggered;
+    }
+
+    public static class Builder<T extends Builder<T>> extends PipelineComponent.Builder<T> {
+        protected boolean wasManuallyTriggered = false;
+
+        public T wasManuallyTriggered(boolean wasManuallyTriggered) {
+            this.wasManuallyTriggered = wasManuallyTriggered;
+            return self();
+        }
+        public PCManualPromotionGate build() {
+            return new PCManualPromotionGate(id, wasManuallyTriggered);
+        }
+    }
+
+    public static Builder<?> builder() {
+        return new Builder();
+    }
+}

--- a/src/main/java/com/distelli/europa/models/PCManualPromotionGate.java
+++ b/src/main/java/com/distelli/europa/models/PCManualPromotionGate.java
@@ -14,13 +14,11 @@ public class PCManualPromotionGate extends PipelineComponent {
     /**
      * Always ends pipeline execution
      *
-     * @param srcRepo Ignored
-     * @param srcTag Ignored
-     * @param manifestDigestSha Ignored
+     * @param promotedImage Ignored
      * @return Always an empty Optional
      */
     @Override
-    public Optional<PromotedImage> execute(ContainerRepo srcRepo, String srcTag, String manifestDigestSha) {
+    public Optional<PromotedImage> execute(PromotedImage promotedImage) {
         return (Optional.empty());
     }
 }

--- a/src/main/java/com/distelli/europa/models/PipelineComponent.java
+++ b/src/main/java/com/distelli/europa/models/PipelineComponent.java
@@ -17,18 +17,18 @@ public class PipelineComponent {
     /**
      * Run the pipeline stage
      *
-     * @param repo the source repo with the image being promoted
-     * @param tag the tag of the image to be promoted
-     * @param manifestDigestSha the SHA digest of the manifest of the image to
-     *                          be promoted
+     * @param promotedImage the metadata about the previous image
      * @return the metadata about the image that was promoted, or an empty
      *         Optional if the stage failed and the pipeline should stop
      * @throws Exception
      */
-    public Optional<PromotedImage> execute(ContainerRepo repo, String tag, String manifestDigestSha) throws Exception {
-        return (Optional.of(new PromotedImage(repo, tag, manifestDigestSha)));
+    public Optional<PromotedImage> execute(PromotedImage promotedImage) throws Exception {
+        return (Optional.of(promotedImage));
     }
 
+    /**
+     * The metadata about an image that was promoted through a pipeline stage
+     */
     @Value
     public static final class PromotedImage {
         private final ContainerRepo repo;

--- a/src/main/java/com/distelli/europa/models/PipelineComponent.java
+++ b/src/main/java/com/distelli/europa/models/PipelineComponent.java
@@ -1,11 +1,9 @@
 package com.distelli.europa.models;
 
-import lombok.Data;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
-import lombok.AllArgsConstructor;
-import lombok.Singular;
 import com.distelli.webserver.AjaxClientException;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
@@ -15,6 +13,10 @@ public class PipelineComponent {
 
     // Used by RunPipeline:
     public boolean execute(ContainerRepo repo, String tag, String manifestDigestSha) throws Exception {
+        return execute(repo, tag, manifestDigestSha, null);
+    }
+
+    public boolean execute(ContainerRepo srcRepo, String srcTag, String manifestDigestSha, String destinationTag) throws Exception {
         return true;
     }
 

--- a/src/main/java/com/distelli/europa/models/PipelineComponent.java
+++ b/src/main/java/com/distelli/europa/models/PipelineComponent.java
@@ -6,23 +6,34 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Value;
 
+import java.util.Optional;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class PipelineComponent {
     private String id;
 
-    // Used by RunPipeline:
-    public PipelineComponentResult execute(ContainerRepo repo, String tag, String manifestDigestSha) throws Exception {
-        return (new PipelineComponentResult(true, repo, tag, manifestDigestSha));
+    /**
+     * Run the pipeline stage
+     *
+     * @param repo the source repo with the image being promoted
+     * @param tag the tag of the image to be promoted
+     * @param manifestDigestSha the SHA digest of the manifest of the image to
+     *                          be promoted
+     * @return the metadata about the image that was promoted, or an empty
+     *         Optional if the stage failed and the pipeline should stop
+     * @throws Exception
+     */
+    public Optional<PromotedImage> execute(ContainerRepo repo, String tag, String manifestDigestSha) throws Exception {
+        return (Optional.of(new PromotedImage(repo, tag, manifestDigestSha)));
     }
 
     @Value
-    public class PipelineComponentResult {
-        boolean successful;
-        ContainerRepo repo;
-        String tag;
-        String manifestDigestSha;
+    public static final class PromotedImage {
+        private final ContainerRepo repo;
+        private final String tag;
+        private final String manifestDigestSha;
     }
 
     // Used by AddPipelineComponent AJAX handler:

--- a/src/main/java/com/distelli/europa/models/PipelineComponent.java
+++ b/src/main/java/com/distelli/europa/models/PipelineComponent.java
@@ -4,6 +4,7 @@ import com.distelli.webserver.AjaxClientException;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.Value;
 
 @Data
 @NoArgsConstructor
@@ -12,12 +13,16 @@ public class PipelineComponent {
     private String id;
 
     // Used by RunPipeline:
-    public boolean execute(ContainerRepo repo, String tag, String manifestDigestSha) throws Exception {
-        return execute(repo, tag, manifestDigestSha, null);
+    public PipelineComponentResult execute(ContainerRepo repo, String tag, String manifestDigestSha) throws Exception {
+        return (new PipelineComponentResult(true, repo, tag, manifestDigestSha));
     }
 
-    public boolean execute(ContainerRepo srcRepo, String srcTag, String manifestDigestSha, String destinationTag) throws Exception {
-        return true;
+    @Value
+    public class PipelineComponentResult {
+        boolean successful;
+        ContainerRepo repo;
+        String tag;
+        String manifestDigestSha;
     }
 
     // Used by AddPipelineComponent AJAX handler:

--- a/src/main/java/com/distelli/europa/pipeline/RunPipeline.java
+++ b/src/main/java/com/distelli/europa/pipeline/RunPipeline.java
@@ -1,12 +1,13 @@
 package com.distelli.europa.pipeline;
 
 import com.distelli.europa.models.ContainerRepo;
-import com.distelli.europa.models.Pipeline;
 import com.distelli.europa.models.PipelineComponent;
 import com.google.inject.Injector;
+import lombok.extern.log4j.Log4j;
+
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import lombok.extern.log4j.Log4j;
+import java.util.List;
 
 @Log4j
 @Singleton
@@ -14,11 +15,15 @@ public class RunPipeline {
     @Inject
     private Injector _injector;
 
-    public void runPipeline(Pipeline pipeline, ContainerRepo repo, String tag, String digest) {
-        for ( PipelineComponent component : pipeline.getComponents() ) {
+    public void runPipeline(List<PipelineComponent> components,
+                            ContainerRepo srcRepo,
+                            String srcTag,
+                            String digest,
+                            String destinationTag) {
+        for ( PipelineComponent component : components) {
             try {
                 _injector.injectMembers(component);
-                if ( ! component.execute(repo, tag, digest) ) break;
+                if ( ! component.execute(srcRepo, srcTag, digest, destinationTag) ) break;
             } catch ( Exception ex ) {
                 // Ignore exceptions caused by threads being interrupted:
                 if ( ex instanceof java.io.InterruptedIOException ) return;

--- a/src/main/java/com/distelli/europa/pipeline/RunPipeline.java
+++ b/src/main/java/com/distelli/europa/pipeline/RunPipeline.java
@@ -20,18 +20,14 @@ public class RunPipeline {
                             ContainerRepo srcRepo,
                             String srcTag,
                             String digest) {
-        Optional<PipelineComponent.PromotedImage> result;
+        Optional<PipelineComponent.PromotedImage> result = Optional.of(new PipelineComponent.PromotedImage(srcRepo, srcTag, digest));
         for ( PipelineComponent component : components) {
             try {
-                _injector.injectMembers(component);
-                result = component.execute(srcRepo, srcTag, digest);
-                if (result.isPresent()) {
-                    srcRepo = result.get().getRepo();
-                    srcTag = result.get().getTag();
-                    digest = result.get().getManifestDigestSha();
-                } else {
+                if (!result.isPresent()) {
                     break;
                 }
+                _injector.injectMembers(component);
+                result = component.execute(result.get());
             } catch ( Exception ex ) {
                 // Ignore exceptions caused by threads being interrupted:
                 if ( ex instanceof java.io.InterruptedIOException ) return;

--- a/src/main/java/com/distelli/europa/pipeline/RunPipeline.java
+++ b/src/main/java/com/distelli/europa/pipeline/RunPipeline.java
@@ -18,12 +18,19 @@ public class RunPipeline {
     public void runPipeline(List<PipelineComponent> components,
                             ContainerRepo srcRepo,
                             String srcTag,
-                            String digest,
-                            String destinationTag) {
+                            String digest) {
+        PipelineComponent.PipelineComponentResult result;
         for ( PipelineComponent component : components) {
             try {
                 _injector.injectMembers(component);
-                if ( ! component.execute(srcRepo, srcTag, digest, destinationTag) ) break;
+                result = component.execute(srcRepo, srcTag, digest);
+                if (result.isSuccessful()) {
+                    srcRepo = result.getRepo();
+                    srcTag = result.getTag();
+                    digest = result.getManifestDigestSha();
+                } else {
+                    break;
+                }
             } catch ( Exception ex ) {
                 // Ignore exceptions caused by threads being interrupted:
                 if ( ex instanceof java.io.InterruptedIOException ) return;

--- a/src/main/java/com/distelli/europa/pipeline/RunPipeline.java
+++ b/src/main/java/com/distelli/europa/pipeline/RunPipeline.java
@@ -8,6 +8,7 @@ import lombok.extern.log4j.Log4j;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.List;
+import java.util.Optional;
 
 @Log4j
 @Singleton
@@ -19,15 +20,15 @@ public class RunPipeline {
                             ContainerRepo srcRepo,
                             String srcTag,
                             String digest) {
-        PipelineComponent.PipelineComponentResult result;
+        Optional<PipelineComponent.PromotedImage> result;
         for ( PipelineComponent component : components) {
             try {
                 _injector.injectMembers(component);
                 result = component.execute(srcRepo, srcTag, digest);
-                if (result.isSuccessful()) {
-                    srcRepo = result.getRepo();
-                    srcTag = result.getTag();
-                    digest = result.getManifestDigestSha();
+                if (result.isPresent()) {
+                    srcRepo = result.get().getRepo();
+                    srcTag = result.get().getTag();
+                    digest = result.get().getManifestDigestSha();
                 } else {
                     break;
                 }

--- a/src/main/java/com/distelli/europa/tasks/PipelineTask.java
+++ b/src/main/java/com/distelli/europa/tasks/PipelineTask.java
@@ -1,26 +1,25 @@
 package com.distelli.europa.tasks;
 
-import com.distelli.europa.db.TasksDb;
-import com.distelli.europa.db.PipelineDb;
 import com.distelli.europa.db.ContainerRepoDb;
+import com.distelli.europa.db.PipelineDb;
 import com.distelli.europa.db.RegistryManifestDb;
-import com.distelli.europa.pipeline.RunPipeline;
-import com.distelli.europa.models.RawTaskEntry;
-import com.distelli.europa.models.Monitor;
-import com.distelli.europa.models.Pipeline;
 import com.distelli.europa.models.ContainerRepo;
+import com.distelli.europa.models.Pipeline;
+import com.distelli.europa.models.RawTaskEntry;
 import com.distelli.europa.models.RegistryManifest;
+import com.distelli.europa.pipeline.RunPipeline;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Injector;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.extern.log4j.Log4j;
+
 import javax.inject.Inject;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collections;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 
 @Log4j
 @Data
@@ -82,7 +81,7 @@ public class PipelineTask implements Task {
                     reference = manifestId;
                 }
             }
-            _runPipeline.runPipeline(pipeline, repo, reference, manifestId);
+            _runPipeline.runPipeline(pipeline.getComponents(), repo, reference, manifestId, null);
         }
     }
 

--- a/src/main/java/com/distelli/europa/tasks/PipelineTask.java
+++ b/src/main/java/com/distelli/europa/tasks/PipelineTask.java
@@ -81,7 +81,7 @@ public class PipelineTask implements Task {
                     reference = manifestId;
                 }
             }
-            _runPipeline.runPipeline(pipeline.getComponents(), repo, reference, manifestId, null);
+            _runPipeline.runPipeline(pipeline.getComponents(), repo, reference, manifestId);
         }
     }
 

--- a/src/test/java/com/distelli/europa/ajax/TestRunPipelineManualPromotion.java
+++ b/src/test/java/com/distelli/europa/ajax/TestRunPipelineManualPromotion.java
@@ -1,0 +1,95 @@
+package com.distelli.europa.ajax;
+
+import com.distelli.europa.EuropaConfiguration;
+import com.distelli.europa.guice.EuropaInjectorModule;
+import com.distelli.europa.models.PCCopyToRepository;
+import com.distelli.europa.models.Pipeline;
+import com.distelli.europa.models.PipelineComponent;
+import com.distelli.objectStore.impl.ObjectStoreModule;
+import com.distelli.persistence.impl.PersistenceModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class TestRunPipelineManualPromotion {
+    private static Injector INJECTOR = createInjector();
+
+    private static Injector createInjector() {
+        String path = System.getenv("EUROPA_CONFIG");
+        EuropaConfiguration config = null;
+        if(path != null) {
+            File file = new File(path);
+            if(!file.exists())
+                throw(new IllegalStateException("Invalid value for EUROPA_CONFIG env var: "+path));
+            config = EuropaConfiguration.fromFile(file);
+        } else {
+            config = EuropaConfiguration.fromEnvironment();
+        }
+        return Guice.createInjector(
+            new PersistenceModule(),
+            new ObjectStoreModule(),
+            new EuropaInjectorModule(
+                config));
+    }
+
+    @Inject
+    private RunPipelineManualPromotion _runPipelineManualPromotion;
+
+    @Before
+    public void before() throws Exception {
+        if ( null == INJECTOR ) {
+            throw new RuntimeException("EUROPA_CONFIG environment variable must point to valid file");
+        }
+        INJECTOR.injectMembers(this);
+    }
+
+    @Test
+    public void testGetComponentsToRun() {
+        Pipeline pipeline = Pipeline.builder()
+            .name("super-pipes")
+            .domain(UUID.randomUUID().toString())
+            .components(
+                Arrays.asList(
+                    PCCopyToRepository.builder()
+                        .id(UUID.randomUUID().toString())
+                        .destinationContainerRepoId("A")
+                        .build(),
+                    PCCopyToRepository.builder()
+                        .id(UUID.randomUUID().toString())
+                        .destinationContainerRepoId("B")
+                        .build(),
+                    PCCopyToRepository.builder()
+                        .id(UUID.randomUUID().toString())
+                        .destinationContainerRepoId("C")
+                        .build(),
+                    PCCopyToRepository.builder()
+                        .id(UUID.randomUUID().toString())
+                        .destinationContainerRepoId("D")
+                        .build(),
+                    PCCopyToRepository.builder()
+                        .id(UUID.randomUUID().toString())
+                        .destinationContainerRepoId("E")
+                        .build()))
+            .build();
+
+        List<PipelineComponent> expectedResult = pipeline.getComponents().subList(1,5);
+        String componentId = pipeline.getComponents()
+            .stream()
+            .filter((pipelineComponent) -> ((PCCopyToRepository)pipelineComponent).getDestinationContainerRepoId().equalsIgnoreCase("B"))
+            .map(PipelineComponent::getId)
+            .findFirst()
+            .orElseThrow(() -> new NullPointerException("Can't find component for some reason"));
+        List<PipelineComponent> actualResult = _runPipelineManualPromotion.getComponentsToRun(pipeline, componentId);
+        assertThat(actualResult, equalTo(expectedResult));
+    }
+}

--- a/src/test/java/com/distelli/europa/models/TestPCManualPromotionGate.java
+++ b/src/test/java/com/distelli/europa/models/TestPCManualPromotionGate.java
@@ -1,0 +1,27 @@
+package com.distelli.europa.models;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class TestPCManualPromotionGate {
+    @Test
+    public void testFailure() throws Exception {
+        PipelineComponent pipelineComponent = PCManualPromotionGate.builder()
+            .id("dummy")
+            .build();
+        boolean result = pipelineComponent.execute(null, null, null, null);
+        assertThat(result, equalTo(false));
+    }
+
+    @Test
+    public void testSuccess() throws Exception {
+        PipelineComponent pipelineComponent = PCManualPromotionGate.builder()
+            .id("dummy")
+            .wasManuallyTriggered(true)
+            .build();
+        boolean result = pipelineComponent.execute(null, null, null, null);
+        assertThat(result, equalTo(true));
+    }
+}

--- a/src/test/java/com/distelli/europa/models/TestPCManualPromotionGate.java
+++ b/src/test/java/com/distelli/europa/models/TestPCManualPromotionGate.java
@@ -11,7 +11,7 @@ public class TestPCManualPromotionGate {
     @Test
     public void test() throws Exception {
         PipelineComponent pipelineComponent = new PCManualPromotionGate();
-        Optional<PipelineComponent.PromotedImage> result = pipelineComponent.execute(null, null, null);
+        Optional<PipelineComponent.PromotedImage> result = pipelineComponent.execute(null);
         assertThat(result.isPresent(), equalTo(false));
     }
 }

--- a/src/test/java/com/distelli/europa/models/TestPCManualPromotionGate.java
+++ b/src/test/java/com/distelli/europa/models/TestPCManualPromotionGate.java
@@ -2,6 +2,8 @@ package com.distelli.europa.models;
 
 import org.junit.Test;
 
+import java.util.Optional;
+
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -9,7 +11,7 @@ public class TestPCManualPromotionGate {
     @Test
     public void test() throws Exception {
         PipelineComponent pipelineComponent = new PCManualPromotionGate();
-        PipelineComponent.PipelineComponentResult result = pipelineComponent.execute(null, null, null);
-        assertThat(result.isSuccessful(), equalTo(false));
+        Optional<PipelineComponent.PromotedImage> result = pipelineComponent.execute(null, null, null);
+        assertThat(result.isPresent(), equalTo(false));
     }
 }

--- a/src/test/java/com/distelli/europa/models/TestPCManualPromotionGate.java
+++ b/src/test/java/com/distelli/europa/models/TestPCManualPromotionGate.java
@@ -7,21 +7,9 @@ import static org.junit.Assert.assertThat;
 
 public class TestPCManualPromotionGate {
     @Test
-    public void testFailure() throws Exception {
-        PipelineComponent pipelineComponent = PCManualPromotionGate.builder()
-            .id("dummy")
-            .build();
-        boolean result = pipelineComponent.execute(null, null, null, null);
-        assertThat(result, equalTo(false));
-    }
-
-    @Test
-    public void testSuccess() throws Exception {
-        PipelineComponent pipelineComponent = PCManualPromotionGate.builder()
-            .id("dummy")
-            .wasManuallyTriggered(true)
-            .build();
-        boolean result = pipelineComponent.execute(null, null, null, null);
-        assertThat(result, equalTo(true));
+    public void test() throws Exception {
+        PipelineComponent pipelineComponent = new PCManualPromotionGate();
+        PipelineComponent.PipelineComponentResult result = pipelineComponent.execute(null, null, null);
+        assertThat(result.isSuccessful(), equalTo(false));
     }
 }


### PR DESCRIPTION
This adds the `PCManualPromotionGate` class as a `PipelineComponent` subclass
to support requiring a manual promotion step in a pipeline. This also sets up
some related prerequisites for supporting manual promotions.

This isn't actually used anywhere yet.