### PR TITLE
Improve config error log output

### DIFF
--- a/src/main/java/com/distelli/europa/Europa.java
+++ b/src/main/java/com/distelli/europa/Europa.java
@@ -19,11 +19,21 @@ import com.distelli.europa.monitor.DispatchRepoMonitorTasks;
 import com.distelli.europa.util.CmdLineArgs;
 import com.distelli.objectStore.impl.ObjectStoreModule;
 import com.distelli.persistence.impl.PersistenceModule;
-import com.distelli.webserver.*;
+import com.distelli.webserver.HTTPMethod;
+import com.distelli.webserver.MatchedRoute;
+import com.distelli.webserver.RequestContext;
+import com.distelli.webserver.RequestContextFactory;
+import com.distelli.webserver.RequestFilter;
+import com.distelli.webserver.RequestHandler;
+import com.distelli.webserver.RequestHandlerFactory;
+import com.distelli.webserver.RouteMatcher;
+import com.distelli.webserver.WebServer;
+import com.distelli.webserver.WebServlet;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Stage;
 import lombok.extern.log4j.Log4j;
+import org.apache.log4j.Logger;
 import org.eclipse.jetty.servlet.DefaultServlet;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
@@ -32,6 +42,8 @@ import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import java.io.File;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
 import java.util.List;
 
 @Log4j
@@ -95,6 +107,7 @@ public class Europa
                 throw(new RuntimeException("Invalid value for stage: "+stageArg, t));
             }
         }
+        validateLoggers();
         initialize();
     }
 
@@ -176,6 +189,14 @@ public class Europa
 
         webServer.setErrorHandler(_staticContentErrorHandler);
         webServer.start();
+    }
+
+    private void validateLoggers() throws RuntimeException {
+        Logger logger = Logger.getRootLogger();
+        Enumeration appenders = logger.getAllAppenders();
+        if(Collections.list(appenders).size() == 0) {
+            throw(new RuntimeException("No log4j loggers are configured. Please add \"-Dlog4j.configuration=file:log4j-console-only.properties\" to JVM VM args and create log4j-console-only.properties."));
+        }
     }
 
     public static void main(String[] args)

--- a/src/main/java/com/distelli/europa/EuropaConfiguration.java
+++ b/src/main/java/com/distelli/europa/EuropaConfiguration.java
@@ -99,7 +99,7 @@ public class EuropaConfiguration
     {
         try {
             EuropaConfiguration config = OBJECT_MAPPER.readValue(configFile, EuropaConfiguration.class);
-            config.validateConfigFile();
+            config.validateConfigFile(configFile);
             config.validate();
             return config;
         } catch(Throwable t) {
@@ -107,17 +107,17 @@ public class EuropaConfiguration
         }
     }
 
-    private void validateConfigFile() {
+    private void validateConfigFile(File configFile) {
         if(dbEndpoint == null) {
-            log.error("Configuration error: \"dbEndPoint\" not set in configuration file.");
+            log.error("Configuration error: \"dbEndPoint\" not set in configuration file " + configFile.getAbsolutePath());
             missingConfigSettings = true;
         }
         if(dbUser == null) {
-            log.error("Configuration error: \"dbUser\" not set in configuration file.");
+            log.error("Configuration error: \"dbUser\" not set in configuration file " + configFile.getAbsolutePath());
             missingConfigSettings = true;
         }
         if(dbPass == null) {
-            log.error("Configuration error: \"dbPass\" not set in configuration file.");
+            log.error("Configuration error: \"dbPass\" not set in configuration file " + configFile.getAbsolutePath());
             missingConfigSettings = true;
         }
     }


### PR DESCRIPTION
This PR makes three improvements:

1. Throw an exception with a user-useful error message if no log4j loggers are configured
2. Log errors for all missing configuration settings rather than bailing out after hitting the first one.
3. Explicitly check for key configuration settings when loading configuration from a file; as-is if an empty config file is provided no validation occurs and we simply throw an NPE the first time the setting is used, which is a poor user experience.

The second two improvements are the same commit.