### PR TITLE
(WHO-1131) Fix edition in footer

### DIFF
--- a/assets/js/components/Footer.js
+++ b/assets/js/components/Footer.js
@@ -5,6 +5,7 @@
 import React, { Component, PropTypes } from 'react'
 import {Link} from 'react-router'
 import NPECheck from './../util/NPECheck'
+import capitalize from './../util/Capitalize'
 
 export default class Footer extends Component {
 	constructor(props) {
@@ -52,8 +53,8 @@ export default class Footer extends Component {
 	footer(){
 		let europa;
 
-		if(this.props.requester) {
-			europa = (this.props.isEnterprise) ? 'Enterprise' : 'Premium';
+		if(typeof PAGE_PROPS.europa !== 'undefined') {
+			europa = capitalize(PAGE_PROPS.europa);
 		} else {
 			europa = 'Community';
 		}

--- a/assets/js/components/Footer.js
+++ b/assets/js/components/Footer.js
@@ -51,13 +51,8 @@ export default class Footer extends Component {
 		);
 	}
 	footer(){
-		let europa;
+		let europa = capitalize(PAGE_PROPS.europa);
 
-		if(typeof PAGE_PROPS.europa !== 'undefined') {
-			europa = capitalize(PAGE_PROPS.europa);
-		} else {
-			europa = 'Community';
-		}
 		return (
 			<div className="Footer">
 				<div className="FooterInside">

--- a/assets/js/util/Capitalize.js
+++ b/assets/js/util/Capitalize.js
@@ -1,0 +1,3 @@
+export default function capitalize(str){
+    return str.replace(/\b\w/g, function(l){ return l.toUpperCase() });
+}

--- a/src/main/java/com/distelli/europa/react/JSXProperties.java
+++ b/src/main/java/com/distelli/europa/react/JSXProperties.java
@@ -1,12 +1,8 @@
 package com.distelli.europa.react;
 
-import java.net.InetAddress;
-import javax.inject.Inject;
-
 import com.distelli.europa.EuropaVersion;
 import com.distelli.europa.models.DnsSettings;
-import com.distelli.webserver.*;
-
+import com.distelli.webserver.RequestContext;
 import lombok.extern.log4j.Log4j;
 
 @Log4j
@@ -29,6 +25,11 @@ public class JSXProperties
         if(_dnsSettings == null)
             return null;
         return _dnsSettings.getDnsName();
+    }
+
+    public String getEuropa()
+    {
+        return "community";
     }
 
     public String getVersion()


### PR DESCRIPTION
Fix the logic to set the edition in the footer.

Without this change, the enterprise edition incorrectly reports as community edition after SAML logout, because the old version checks for a requester and requester is not set after logout.