### PR TITLE
Save storage settings on enter keypress

### DIFF
--- a/assets/js/components/StorageSettings.js
+++ b/assets/js/components/StorageSettings.js
@@ -31,6 +31,12 @@ export default class StorageSettings extends Component {
     }
   }
 
+  keyPress(e) {
+    if (e.keyCode == 13) {
+      this.saveStorageSettings()
+    }
+  }
+
   componentWillUnmount() {
     // Avoid race conditions
     setTimeout(() => {
@@ -175,6 +181,7 @@ export default class StorageSettings extends Component {
         <input className={className}
                value={NPECheck(this.props, `settings/storage/storageCreds/${inputConfig.key}`, '')}
                onChange={(e) => this.context.actions.updateStorageCreds(inputConfig.key, e)}
+               onKeyDown={(e) => this.keyPress(e)}
                placeholder={inputConfig.placeholder}
                type={inputConfig.type}
                {...readOnly} />


### PR DESCRIPTION
Save storage settings when the user hits enter.

Without this change it's annoying to run through the storage setup and having to click save and not be able to simply hit enter.