### PR TITLE
(WHO-984) Improve _catalog pagination

### DIFF
--- a/src/main/java/com/distelli/europa/db/ContainerRepoDb.java
+++ b/src/main/java/com/distelli/europa/db/ContainerRepoDb.java
@@ -140,7 +140,7 @@ public class ContainerRepoDb extends BaseDb
         .withHashKeyName("hk")
         .withRangeKeyName("sidx")
         .withConvertValue(_om::convertValue)
-        .withConvertMarker(convertMarkerFactory.create("hk", "sidx"))
+        .withConvertMarker(convertMarkerFactory.create("hk", "sidx", "id"))
         .build();
 
         _byCredId = indexFactory.create(ContainerRepo.class)

--- a/src/main/java/com/distelli/europa/db/ContainerRepoDb.java
+++ b/src/main/java/com/distelli/europa/db/ContainerRepoDb.java
@@ -13,7 +13,6 @@ import com.distelli.europa.models.RegistryProvider;
 import com.distelli.europa.models.RepoEvent;
 import com.distelli.jackson.transform.TransformModule;
 import com.distelli.persistence.AttrType;
-import com.distelli.persistence.Attribute;
 import com.distelli.persistence.ConvertMarker;
 import com.distelli.persistence.Index;
 import com.distelli.persistence.IndexDescription;
@@ -32,7 +31,6 @@ import javax.inject.Inject;
 import javax.persistence.RollbackException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 
 @Log4j
 @Singleton
@@ -142,40 +140,7 @@ public class ContainerRepoDb extends BaseDb
         .withHashKeyName("hk")
         .withRangeKeyName("sidx")
         .withConvertValue(_om::convertValue)
-            // Custom convert marker implementation to support /v2/_catalog API:
-            .withConvertMarker(new ConvertMarker() {
-                    public String toMarker(Map<String, Object> attributes, boolean hasHashKey) {
-                        if ( hasHashKey ) {
-                            return CompositeKey.build(""+attributes.get("sidx"),
-                                                      ""+attributes.get("id"));
-                        }
-                        // TODO: implement...
-                        throw new UnsupportedOperationException("scan is not supported");
-                    }
-                    public Attribute[] fromMarker(Object hk, String marker) {
-                        String[] attrs = CompositeKey.split(marker, 4);
-                        if ( null == attrs || attrs.length != 4 ) {
-                            throw new IllegalArgumentException("Expected marker in format "+CompositeKey.build("<provider>",
-                                                                                                               "<region>",
-                                                                                                               "<name>",
-                                                                                                               "<id>")+" got="+marker);
-                        }
-                        return new Attribute[] {
-                            new Attribute()
-                            .withName("hk")
-                            .withValue(hk),
-                            new Attribute()
-                            .withName("sidx")
-                            .withValue(getSecondaryKey(
-                                           RegistryProvider.valueOf(attrs[0].toUpperCase()),
-                                           attrs[1],
-                                           attrs[2])),
-                            new Attribute()
-                            .withName("id")
-                            .withValue(attrs[3])
-                        };
-                    }
-                })
+        .withConvertMarker(convertMarkerFactory.create("hk", "sidx"))
         .build();
 
         _byCredId = indexFactory.create(ContainerRepo.class)
@@ -233,49 +198,10 @@ public class ContainerRepoDb extends BaseDb
     public List<ContainerRepo> listEuropaRepos(String domain,
                                                PageIterator pageIterator)
     {
-        String marker = pageIterator.getMarker();
-        String newMarker = null;
-        if ( null != marker ) {
-            String sidx = getSecondaryKey(
-                RegistryProvider.EUROPA,
-                "",
-                marker);
-            ContainerRepo repo = null;
-            for ( PageIterator it : new PageIterator().pageSize(100) ) {
-                List<ContainerRepo> list = _secondaryIndex.queryItems(getHashKey(domain), it)
-                    .eq(sidx)
-                    .list();
-                if ( list.size() > 0 ) repo = list.get(list.size()-1);
-            }
-            if ( null == repo ) {
-                newMarker = CompositeKey.buildPrefix(sidx);
-            } else {
-                newMarker = _secondaryIndex.toMarker(repo, true);
-            }
-            pageIterator.marker(newMarker);
-        }
-
         String rangeKey = CompositeKey.buildPrefix(RegistryProvider.EUROPA.toString().toLowerCase());
-        try {
-            return _secondaryIndex.queryItems(getHashKey(domain), pageIterator)
-                .beginsWith(rangeKey)
-                .list();
-        } finally {
-            String outMarker = pageIterator.getMarker();
-            if ( null != outMarker ) {
-                if ( newMarker != null && newMarker.equals(outMarker) ) {
-                    // restore...
-                    pageIterator.marker(marker);
-                } else if ( outMarker.startsWith(rangeKey) ) {
-                    String[] attrs = CompositeKey.split(outMarker, 4);
-                    if ( attrs.length != 4 ) throw new IllegalStateException("Unexpected marker="+marker);
-                    pageIterator.marker(attrs[2]);
-                } else {
-                    throw new IllegalStateException(
-                        "Expected marker to begin with "+rangeKey+" marker="+outMarker);
-                }
-            }
-        }
+        return _secondaryIndex.queryItems(getHashKey(domain), pageIterator)
+            .beginsWith(rangeKey)
+            .list();
     }
 
     public List<ContainerRepo> listRepos(String domain,
@@ -395,15 +321,11 @@ public class ContainerRepoDb extends BaseDb
         }
     }
 
-    public String getMainIndexMarker(ContainerRepo repo) {
-        return _main.toMarker(repo, false);
+    public String getMainIndexMarker(ContainerRepo repo, boolean hasHashKey) {
+        return _main.toMarker(repo, hasHashKey);
     }
 
-    public String getSecondaryIndexMarker(ContainerRepo repo) {
-        String marker = _secondaryIndex.toMarker(repo, true);
-        String[] attrs =  CompositeKey.split(marker);
-        if ( attrs.length != 4 ) throw new IllegalStateException("Unexpected marker="+marker);
-        return attrs[2];
-
+    public String getSecondaryIndexMarker(ContainerRepo repo, boolean hasHashKey) {
+        return _secondaryIndex.toMarker(repo, hasHashKey);
     }
 }

--- a/src/main/java/com/distelli/europa/db/ContainerRepoDb.java
+++ b/src/main/java/com/distelli/europa/db/ContainerRepoDb.java
@@ -8,16 +8,10 @@
 */
 package com.distelli.europa.db;
 
-import java.util.Arrays;
-import java.util.List;
-import javax.inject.Inject;
-
-import com.distelli.utils.CompositeKey;
-import com.distelli.europa.Constants;
-import com.distelli.europa.ajax.*;
-import com.distelli.europa.models.*;
+import com.distelli.europa.models.ContainerRepo;
+import com.distelli.europa.models.RegistryProvider;
+import com.distelli.europa.models.RepoEvent;
 import com.distelli.jackson.transform.TransformModule;
-import com.distelli.persistence.AttrDescription;
 import com.distelli.persistence.AttrType;
 import com.distelli.persistence.Attribute;
 import com.distelli.persistence.ConvertMarker;
@@ -26,13 +20,19 @@ import com.distelli.persistence.IndexDescription;
 import com.distelli.persistence.IndexType;
 import com.distelli.persistence.PageIterator;
 import com.distelli.persistence.TableDescription;
-import com.distelli.webserver.*;
+import com.distelli.utils.CompositeKey;
+import com.distelli.webserver.AjaxClientException;
+import com.distelli.webserver.JsonError;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Singleton;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import java.util.Map;
 import lombok.extern.log4j.Log4j;
+
+import javax.inject.Inject;
 import javax.persistence.RollbackException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 @Log4j
 @Singleton
@@ -393,5 +393,17 @@ public class ContainerRepoDb extends BaseDb
         } catch ( RollbackException ex ) {
             return false;
         }
+    }
+
+    public String getMainIndexMarker(ContainerRepo repo) {
+        return _main.toMarker(repo, false);
+    }
+
+    public String getSecondaryIndexMarker(ContainerRepo repo) {
+        String marker = _secondaryIndex.toMarker(repo, true);
+        String[] attrs =  CompositeKey.split(marker);
+        if ( attrs.length != 4 ) throw new IllegalStateException("Unexpected marker="+marker);
+        return attrs[2];
+
     }
 }

--- a/src/main/java/com/distelli/europa/handlers/RegistryBase.java
+++ b/src/main/java/com/distelli/europa/handlers/RegistryBase.java
@@ -114,7 +114,7 @@ public abstract class RegistryBase extends RequestHandler<EuropaRequestContext>
         //     Link: </uri/path/to/resource?foo=bar;baz=1>; rel=next
         // Note that the URI is surrounded by angle brackets, per RFC 5988.
         if (pageIterator.getMarker() != null) {
-            StringBuilder linkUriBuilder = new StringBuilder("/");
+            StringBuilder linkUriBuilder = new StringBuilder("</");
             linkUriBuilder.append(String.join("/", pathComponents));
             linkUriBuilder.append("?last=");
             linkUriBuilder.append(pageIterator.getMarker());
@@ -122,7 +122,6 @@ public abstract class RegistryBase extends RequestHandler<EuropaRequestContext>
                 linkUriBuilder.append("&n=");
                 linkUriBuilder.append(pageIterator.getPageSize());
             }
-            linkUriBuilder.insert(0, "<");
             linkUriBuilder.append(">; rel=\"next\"");
             webResponse.setResponseHeader("Link", linkUriBuilder.toString());
         }

--- a/src/main/java/com/distelli/europa/handlers/RegistryBase.java
+++ b/src/main/java/com/distelli/europa/handlers/RegistryBase.java
@@ -1,33 +1,28 @@
 package com.distelli.europa.handlers;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.StringJoiner;
-import javax.inject.Inject;
-import javax.inject.Singleton;
-
-import org.eclipse.jetty.http.HttpMethod;
 import com.distelli.europa.EuropaRequestContext;
 import com.distelli.europa.db.ContainerRepoDb;
 import com.distelli.europa.guice.ObjectStoreNotInitialized;
 import com.distelli.europa.models.ContainerRepo;
 import com.distelli.europa.models.RegistryProvider;
-import com.distelli.europa.registry.RegistryAuth;
 import com.distelli.europa.registry.RegistryError;
 import com.distelli.europa.registry.RegistryErrorCode;
 import com.distelli.europa.util.PermissionCheck;
+import com.distelli.persistence.PageIterator;
 import com.distelli.utils.CompactUUID;
-import com.distelli.webserver.AjaxClientException;
 import com.distelli.webserver.RequestContext;
 import com.distelli.webserver.RequestHandler;
 import com.distelli.webserver.WebResponse;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import lombok.extern.log4j.Log4j;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Map;
+import java.util.StringJoiner;
 
 @Log4j
 @Singleton
@@ -95,6 +90,43 @@ public abstract class RegistryBase extends RequestHandler<EuropaRequestContext>
             joiner.add(part);
         }
         return joiner.toString();
+    }
+
+    /**
+     * Sets the Link HTTP header for pagination, if applicable
+     *
+     * If {@code pageIterator.getMarker()} returns {@code null}, this does
+     * nothing. Otherwise, it adds a {@code Link} header to the provided
+     * WebResponse object and returns the object again. Note that you need to
+     * specify all the components of the path, e.g.,
+     * <p>
+     * {@code addPaginationLinkHeader(webResponse, pageIterator, "v2", ownerUsername, "_catalog")}
+     *
+     * @param webResponse the WebResponse to add the header to
+     * @param pageIterator the PageIterator used for pagination
+     * @param pathComponents the components of the path to use, including v2
+     * @return the WebResponse
+     */
+    protected WebResponse addPaginationLinkHeader(WebResponse webResponse,
+                                                  PageIterator pageIterator,
+                                                  String... pathComponents) {
+        // The format for a Link header, at least how we need to use it, is:
+        //     Link: </uri/path/to/resource?foo=bar;baz=1>; rel=next
+        // Note that the URI is surrounded by angle brackets, per RFC 5988.
+        if (pageIterator.getMarker() != null) {
+            StringBuilder linkUriBuilder = new StringBuilder("/");
+            linkUriBuilder.append(String.join("/", pathComponents));
+            linkUriBuilder.append("?last=");
+            linkUriBuilder.append(pageIterator.getMarker());
+            if (DEFAULT_PAGE_SIZE != pageIterator.getPageSize()) {
+                linkUriBuilder.append("&n=");
+                linkUriBuilder.append(pageIterator.getPageSize());
+            }
+            linkUriBuilder.insert(0, "<");
+            linkUriBuilder.append(">; rel=\"next\"");
+            webResponse.setResponseHeader("Link", linkUriBuilder.toString());
+        }
+        return webResponse;
     }
 
     protected int getPageSize(RequestContext requestContext) {

--- a/src/main/java/com/distelli/europa/handlers/RegistryCatalog.java
+++ b/src/main/java/com/distelli/europa/handlers/RegistryCatalog.java
@@ -81,6 +81,6 @@ public class RegistryCatalog extends RegistryBase {
     }
 
     protected String getMarker(ContainerRepo repo, String ownerUsername) {
-        return _reposDb.getSecondaryIndexMarker(repo);
+        return _reposDb.getSecondaryIndexMarker(repo, true);
     }
 }

--- a/src/main/java/com/distelli/europa/handlers/RegistryTagList.java
+++ b/src/main/java/com/distelli/europa/handlers/RegistryTagList.java
@@ -4,24 +4,17 @@ import com.distelli.europa.EuropaRequestContext;
 import com.distelli.europa.db.RegistryManifestDb;
 import com.distelli.europa.models.ContainerRepo;
 import com.distelli.europa.models.RegistryManifest;
-import com.distelli.europa.registry.RegistryError;
-import com.distelli.europa.registry.RegistryErrorCode;
 import com.distelli.persistence.PageIterator;
-import com.distelli.webserver.RequestContext;
-import com.distelli.webserver.RequestHandler;
 import com.distelli.webserver.WebResponse;
-import com.fasterxml.jackson.databind.JsonNode;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
+import lombok.extern.log4j.Log4j;
+
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import lombok.extern.log4j.Log4j;
-import org.eclipse.jetty.http.HttpMethod;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @Log4j
 @Singleton
@@ -62,17 +55,8 @@ public class RegistryTagList extends RegistryBase {
             .map((manifest) -> manifest.getTag())
             .collect(Collectors.toList());
 
-        String location = null;
-        if ( null != it.getMarker() ) {
-            location = joinWithSlash("/v2", ownerUsername, name, "tags/list") + "?last=" + it.getMarker();
-            if ( DEFAULT_PAGE_SIZE != it.getPageSize() ) {
-                location = location + "&n="+it.getPageSize();
-            }
-        }
         WebResponse webResponse = toJson(response);
-        if ( null != location ) {
-            webResponse.setResponseHeader("Link", location + "; rel=\"next\"");
-        }
+        addPaginationLinkHeader(webResponse, it, "v2", ownerUsername, name, "tags", "list");
         return webResponse;
     }
 }


### PR DESCRIPTION
This improves pagination for the _catalog endpoint by ensuring that the
requested number of entries, if there are that many, are returned, regardless
of access control. Without this, if a request lacks access to some of the
results, the number of results returned will be less than the full page size.

This also fixes the format of the `Link` headers returned to be in compliance
with RFC 5988.