### PR TITLE
(WHO-1325) Add batch mirror creation ajax helper

### DIFF
--- a/src/main/java/com/distelli/europa/ajax/CreateLocalRepo.java
+++ b/src/main/java/com/distelli/europa/ajax/CreateLocalRepo.java
@@ -22,7 +22,6 @@ import lombok.extern.log4j.Log4j;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.Collections;
 
 @Log4j
 @Singleton
@@ -53,8 +52,8 @@ public class CreateLocalRepo extends AjaxHelper<EuropaRequestContext>
     {
         String ownerDomain = requestContext.getOwnerDomain();
         String repoName = ajaxRequest.getParam("repoName", true);
-        ContainerRepoDb.RepoNameValidity validity =
-            _repoDb.validateLocalNames(ownerDomain, Collections.singleton(repoName)).get(repoName);
+        ContainerRepoDb.RepoNameValidity validity = _repoDb.validateLocalName(ownerDomain, repoName);
+
         if(ContainerRepoDb.RepoNameValidity.EXISTS == validity) {
             throw(new AjaxClientException("The specified Repository already exists",
                                           AjaxErrors.Codes.RepoAlreadyExists,

--- a/src/main/java/com/distelli/europa/ajax/CreateLocalRepo.java
+++ b/src/main/java/com/distelli/europa/ajax/CreateLocalRepo.java
@@ -22,8 +22,6 @@ import lombok.extern.log4j.Log4j;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @Log4j
 @Singleton
@@ -33,8 +31,6 @@ public class CreateLocalRepo extends AjaxHelper<EuropaRequestContext>
     protected ContainerRepoDb _repoDb;
     @Inject
     protected PermissionCheck _permissionCheck;
-
-    private final Pattern repoNamePattern = Pattern.compile("[a-zA-Z0-9_\\.-]+");
 
     public CreateLocalRepo()
     {
@@ -61,9 +57,8 @@ public class CreateLocalRepo extends AjaxHelper<EuropaRequestContext>
             throw(new AjaxClientException("The specified Repository already exists",
                                           AjaxErrors.Codes.RepoAlreadyExists,
                                           400));
-        Matcher m = repoNamePattern.matcher(repoName);
-        if(!m.matches())
-            throw(new AjaxClientException("The Repo Name is invalid. It must match regex [a-zA-Z0-9_.-]",
+        if(!ContainerRepo.isValidName(repoName))
+            throw(new AjaxClientException("The Repo Name is invalid. It must match regex [a-zA-Z0-9_.-]+",
                                           AjaxErrors.Codes.BadRepoName,
                                           400));
         repo = ContainerRepo.builder()

--- a/src/main/java/com/distelli/europa/ajax/CreateRepoMirrorsBatch.java
+++ b/src/main/java/com/distelli/europa/ajax/CreateRepoMirrorsBatch.java
@@ -1,0 +1,156 @@
+package com.distelli.europa.ajax;
+
+import com.distelli.europa.EuropaRequestContext;
+import com.distelli.europa.db.ContainerRepoDb;
+import com.distelli.europa.db.RegistryCredsDb;
+import com.distelli.europa.db.TasksDb;
+import com.distelli.europa.models.ContainerRepo;
+import com.distelli.europa.models.Monitor;
+import com.distelli.europa.models.RegistryCred;
+import com.distelli.europa.models.RegistryProvider;
+import com.distelli.europa.sync.RepoSyncTask;
+import com.distelli.europa.util.PermissionCheck;
+import com.distelli.utils.CompactUUID;
+import com.distelli.webserver.AjaxClientException;
+import com.distelli.webserver.AjaxHelper;
+import com.distelli.webserver.AjaxRequest;
+import com.distelli.webserver.HTTPMethod;
+import com.distelli.webserver.JsonError;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Data;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class CreateRepoMirrorsBatch extends AjaxHelper<EuropaRequestContext> {
+    private static ObjectMapper OM = new ObjectMapper();
+
+    @Inject
+    private RegistryCredsDb _credsDb;
+    @Inject
+    private ContainerRepoDb _repoDb;
+    @Inject
+    private TasksDb _tasksDb;
+    @Inject
+    private Provider<Monitor> _monitorProvider;
+    @Inject
+    private PermissionCheck _permissionCheck;
+
+    public CreateRepoMirrorsBatch() {
+        this.supportedHttpMethods.add(HTTPMethod.POST);
+    }
+
+    @Override
+    public Object get(AjaxRequest ajaxRequest, EuropaRequestContext requestContext) {
+        _permissionCheck.check(ajaxRequest.getOperation(), requestContext);
+
+        String domain = requestContext.getOwnerDomain();
+        String credId = ajaxRequest.getParam("credId", true);
+        RegistryCred cred = _credsDb.getCred(domain, credId);
+        if (null == cred) {
+            throw(new AjaxClientException(String.format("Invalid Registry Cred: %s", credId),
+                                          JsonError.Codes.BadParam,
+                                          400));
+        }
+
+        JsonNode repos = ajaxRequest.getContent("/repos", true);
+        List<NewMirrorRequest> mirrorRequests = OM.convertValue(repos, new TypeReference<List<NewMirrorRequest>>(){});
+
+        List<String> invalidRepoNames = mirrorRequests.stream()
+            .filter(request -> !ContainerRepo.isValidName(request.getDestinationRepoName()))
+            .map(NewMirrorRequest::getDestinationRepoName)
+            .collect(Collectors.toList());
+        if (!invalidRepoNames.isEmpty()) {
+            String message = String.format("The following repository names are invalid: %s\nRepository names must match the regex [a-zA-Z0-9_.-]+",
+                                          String.join(", ", invalidRepoNames));
+            throw(new AjaxClientException(message, AjaxErrors.Codes.BadRepoName, 400));
+        }
+
+        List<String> existingRepoNames = mirrorRequests.stream()
+            .filter(request -> null != _repoDb.getRepo(domain,
+                                                       RegistryProvider.EUROPA,
+                                                       "",
+                                                       request.getDestinationRepoName()))
+            .map(NewMirrorRequest::getDestinationRepoName)
+            .collect(Collectors.toList());
+
+        if (!existingRepoNames.isEmpty()) {
+            String message = String.format("The following repositories already exist: %s",
+                                           String.join(", ", existingRepoNames));
+            throw(new AjaxClientException(message, AjaxErrors.Codes.RepoAlreadyExists, 400));
+        }
+
+        List<ContainerRepo> containerRepos = new ArrayList<>();
+        for (NewMirrorRequest request : mirrorRequests) {
+            ContainerRepo destinationRepo = newMirrorRepo(domain, request);
+            _repoDb.save(destinationRepo);
+            ContainerRepo sourceRepo = _repoDb.getRepo(domain,
+                                                       cred.getProvider(),
+                                                       cred.getRegion(),
+                                                       request.getSourceRepoName());
+            if (null == sourceRepo) {
+                sourceRepo = newSourceRepo(domain, request, cred, destinationRepo.getId());
+                _repoDb.save(sourceRepo);
+            } else {
+                sourceRepo.getSyncDestinationContainerRepoIds().add(destinationRepo.getId());
+                _repoDb.addSyncDestinationContainerRepoId(domain, sourceRepo.getId(), destinationRepo.getId());
+            }
+            containerRepos.add(sourceRepo);
+            containerRepos.add(destinationRepo);
+            _tasksDb.addTask(_monitorProvider.get(),
+                             RepoSyncTask.builder()
+                                 .domain(domain)
+                                 .sourceRepoId(sourceRepo.getId())
+                                 .destinationRepoId(destinationRepo.getId())
+                                 .build());
+        }
+
+        return containerRepos;
+    }
+
+    private ContainerRepo newMirrorRepo(String domain, NewMirrorRequest request) {
+        return ContainerRepo.builder()
+            .domain(domain)
+            .name(request.getDestinationRepoName())
+            .provider(RegistryProvider.EUROPA)
+            .region("")
+            .local(true)
+            .publicRepo(false)
+            .mirror(true)
+            .id(CompactUUID.randomUUID().toString())
+            .overviewId(CompactUUID.randomUUID().toString())
+            .build();
+    }
+
+    private ContainerRepo newSourceRepo(String domain,
+                                        NewMirrorRequest request,
+                                        RegistryCred cred,
+                                        String destinationRepoId) {
+        return ContainerRepo.builder()
+            .domain(domain)
+            .name(request.getSourceRepoName())
+            .provider(cred.getProvider())
+            .region(cred.getRegion())
+            .local(false)
+            .publicRepo(false)
+            .mirror(false)
+            .credId(cred.getId())
+            .id(CompactUUID.randomUUID().toString())
+            .overviewId(CompactUUID.randomUUID().toString())
+            .syncDestinationContainerRepoIds(new HashSet<>(Collections.singletonList(destinationRepoId)))
+            .build();
+    }
+
+    @Data
+    public static class NewMirrorRequest {
+        private String sourceRepoName;
+        private String destinationRepoName;
+    }
+}

--- a/src/main/java/com/distelli/europa/db/ContainerRepoDb.java
+++ b/src/main/java/com/distelli/europa/db/ContainerRepoDb.java
@@ -32,10 +32,7 @@ import lombok.extern.log4j.Log4j;
 import javax.inject.Inject;
 import javax.persistence.RollbackException;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -363,30 +360,26 @@ public class ContainerRepoDb extends BaseDb
     }
 
     /**
-     * Check whether repository names are valid and available.
+     * Check whether a repository name is valid and available.
      *
      * @param domain the domain to check names under
-     * @param repoNames the names to check
-     * @return a Map between name and validity
+     * @param repoName the name to check
+     * @return the validity status of the name
      */
-    public Map<String, RepoNameValidity> validateLocalNames(String domain, Collection<String> repoNames) {
+    public RepoNameValidity validateLocalName(String domain, String repoName) {
         if (null == domain) {
             throw new NullPointerException("Domain cannot be null");
         }
-        if (null == repoNames) {
-            throw new NullPointerException("Why would you ever pass a null value for a List?");
+        if (null == repoName) {
+            throw new NullPointerException("Repo name cannot be null");
         }
-        Map<String, RepoNameValidity> retval = new HashMap<>();
-        for (String name : repoNames) {
-            if (!isRepoNameValidFormat(name)) {
-                retval.put(name, RepoNameValidity.INVALID);
-            } else if (repoExists(domain, RegistryProvider.EUROPA, "", name)) {
-                retval.put(name, RepoNameValidity.EXISTS);
-            } else {
-                retval.put(name, RepoNameValidity.VALID);
-            }
+        if (!isRepoNameValidFormat(repoName)) {
+            return RepoNameValidity.INVALID;
         }
-        return retval;
+        if (repoExists(domain, RegistryProvider.EUROPA, "", repoName)) {
+            return RepoNameValidity.EXISTS;
+        }
+        return RepoNameValidity.VALID;
     }
 
     /**

--- a/src/main/java/com/distelli/europa/db/ContainerRepoDb.java
+++ b/src/main/java/com/distelli/europa/db/ContainerRepoDb.java
@@ -32,8 +32,12 @@ import lombok.extern.log4j.Log4j;
 import javax.inject.Inject;
 import javax.persistence.RollbackException;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 @Log4j
 @Singleton
@@ -44,6 +48,8 @@ public class ContainerRepoDb extends BaseDb
     private Index<ContainerRepo> _byCredId;
 
     private final ObjectMapper _om = new ObjectMapper();
+
+    private static final Pattern REPO_NAME_PATTERN = Pattern.compile("[a-zA-Z0-9_.-]+");
 
     public static TableDescription getTableDescription() {
         return TableDescription.builder()
@@ -354,5 +360,63 @@ public class ContainerRepoDb extends BaseDb
 
     public String getSecondaryIndexMarker(ContainerRepo repo, boolean hasHashKey) {
         return _secondaryIndex.toMarker(repo, hasHashKey);
+    }
+
+    /**
+     * Check whether repository names are valid and available.
+     *
+     * @param domain the domain to check names under
+     * @param repoNames the names to check
+     * @return a Map between name and validity
+     */
+    public Map<String, RepoNameValidity> validateLocalNames(String domain, Collection<String> repoNames) {
+        if (null == domain) {
+            throw new NullPointerException("Domain cannot be null");
+        }
+        if (null == repoNames) {
+            throw new NullPointerException("Why would you ever pass a null value for a List?");
+        }
+        Map<String, RepoNameValidity> retval = new HashMap<>();
+        for (String name : repoNames) {
+            if (!isRepoNameValidFormat(name)) {
+                retval.put(name, RepoNameValidity.INVALID);
+            } else if (repoExists(domain, RegistryProvider.EUROPA, "", name)) {
+                retval.put(name, RepoNameValidity.EXISTS);
+            } else {
+                retval.put(name, RepoNameValidity.VALID);
+            }
+        }
+        return retval;
+    }
+
+    /**
+     * Check if a repository name is in the valid format.
+     *
+     * A repository name is considered valid if it matches the regular
+     * expression {@code [a-zA-Z0-9_.-]+}.
+     *
+     * @param repoName the name to check
+     * @return true if the name is valid, false if it is not
+     */
+    public boolean isRepoNameValidFormat(String repoName) {
+        return null != repoName && REPO_NAME_PATTERN.matcher(repoName).matches();
+    }
+
+    /**
+     * Represents the validity of a repository name.
+     */
+    public enum RepoNameValidity {
+        /**
+         * The name is valid and available.
+         */
+        VALID,
+        /**
+         * The name is not valid.
+         */
+        INVALID,
+        /**
+         * A repository with the name already exists.
+         */
+        EXISTS;
     }
 }

--- a/src/main/java/com/distelli/europa/guice/AjaxHelperModule.java
+++ b/src/main/java/com/distelli/europa/guice/AjaxHelperModule.java
@@ -12,6 +12,7 @@ import com.distelli.europa.ajax.AddPipelineComponent;
 import com.distelli.europa.ajax.CreateAuthToken;
 import com.distelli.europa.ajax.CreateRepoMirror;
 import com.distelli.europa.ajax.CreateLocalRepo;
+import com.distelli.europa.ajax.CreateRepoMirrorsBatch;
 import com.distelli.europa.ajax.DeleteAuthToken;
 import com.distelli.europa.ajax.DeleteContainerRepo;
 import com.distelli.europa.ajax.DeletePipelineContainerRepoId;
@@ -95,6 +96,7 @@ public class AjaxHelperModule extends AbstractModule
         addBinding(SaveContainerRepo.class);
         addBinding(CreateLocalRepo.class);
         addBinding(CreateRepoMirror.class);
+        addBinding(CreateRepoMirrorsBatch.class);
         addBinding(GetContainerRepo.class);
         addBinding(ListContainerRepos.class);
         addBinding(DeleteContainerRepo.class);

--- a/src/main/java/com/distelli/europa/models/ContainerRepo.java
+++ b/src/main/java/com/distelli/europa/models/ContainerRepo.java
@@ -7,7 +7,6 @@ import lombok.NoArgsConstructor;
 
 import java.util.HashSet;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 @Data
 @Builder
@@ -15,8 +14,6 @@ import java.util.regex.Pattern;
 @AllArgsConstructor
 public class ContainerRepo
 {
-    private static final Pattern REPO_NAME_PATTERN = Pattern.compile("[a-zA-Z0-9_.-]+");
-
     protected String domain = null;
     protected String id = null;
     protected String name = null;
@@ -73,17 +70,5 @@ public class ContainerRepo
         default:
             return null;
         }
-    }
-
-    /**
-     * Check if a repository name is valid.
-     *
-     * A repository name is considered valid if it matches the regular
-     * expression {@code [a-zA-Z0-9_.-]+}.
-     * @param repoName the repository name to check
-     * @return true if the name is valid, false if it is not
-     */
-    public static boolean isValidName(String repoName) {
-        return null != repoName && REPO_NAME_PATTERN.matcher(repoName).matches();
     }
 }

--- a/src/main/java/com/distelli/europa/models/ContainerRepo.java
+++ b/src/main/java/com/distelli/europa/models/ContainerRepo.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 @Data
 @Builder
@@ -14,6 +15,8 @@ import java.util.Set;
 @AllArgsConstructor
 public class ContainerRepo
 {
+    private static final Pattern REPO_NAME_PATTERN = Pattern.compile("[a-zA-Z0-9_.-]+");
+
     protected String domain = null;
     protected String id = null;
     protected String name = null;
@@ -70,5 +73,17 @@ public class ContainerRepo
         default:
             return null;
         }
+    }
+
+    /**
+     * Check if a repository name is valid.
+     *
+     * A repository name is considered valid if it matches the regular
+     * expression {@code [a-zA-Z0-9_.-]+}.
+     * @param repoName the repository name to check
+     * @return true if the name is valid, false if it is not
+     */
+    public static boolean isValidName(String repoName) {
+        return null != repoName && REPO_NAME_PATTERN.matcher(repoName).matches();
     }
 }


### PR DESCRIPTION
This adds a new ajax helper, `CreateRepoMirrorsBatch`, which supports creating
multiple local repository mirrors from a single ajax call. It will create new
remote repos if they don't exist, or use the existing ones if they do.