### PR TITLE
(WHO-1316) Disallow adding mirrors to pipelines

### DIFF
--- a/assets/js/components/PipelineConnectRepository.js
+++ b/assets/js/components/PipelineConnectRepository.js
@@ -77,8 +77,9 @@ export default class PipelineConnectRepository extends Component {
     }, {})
 
     return this.props.repos.filter(repo => this.props.pipelineStore.pipeline.containerRepoId != repo.id)
-    .filter(repo => !mapOfComponentIds.hasOwnProperty(repo.id))
-    .filter(repo => (this.props.initialConnect && !repo.local) ? false : true)
+      .filter(repo => !mapOfComponentIds.hasOwnProperty(repo.id))
+      .filter(repo => (this.props.initialConnect && !repo.local) ? false : true)
+      .filter(repo => !repo.mirror);
   }
 
   render() {

--- a/src/main/java/com/distelli/europa/ajax/AddPipelineComponent.java
+++ b/src/main/java/com/distelli/europa/ajax/AddPipelineComponent.java
@@ -9,6 +9,7 @@ import com.distelli.europa.util.PermissionCheck;
 import com.distelli.webserver.AjaxHelper;
 import com.distelli.webserver.AjaxRequest;
 import com.distelli.webserver.HTTPMethod;
+import com.google.inject.Injector;
 import com.google.inject.Singleton;
 import lombok.extern.log4j.Log4j;
 
@@ -30,6 +31,8 @@ public class AddPipelineComponent extends AjaxHelper<EuropaRequestContext>
     private PipelineDb _db;
     @Inject
     protected PermissionCheck _permissionCheck;
+    @Inject
+    private Injector _injector;
 
     public AddPipelineComponent()
     {
@@ -45,6 +48,7 @@ public class AddPipelineComponent extends AjaxHelper<EuropaRequestContext>
         Class<? extends PipelineComponent> type = TYPES.get(typeName);
 
         PipelineComponent component = ajaxRequest.convertContent(type, true);
+        _injector.injectMembers(component);
         component.validate("content@"+typeName);
 
         _db.addPipelineComponent(

--- a/src/main/java/com/distelli/europa/models/PCCopyToRepository.java
+++ b/src/main/java/com/distelli/europa/models/PCCopyToRepository.java
@@ -103,6 +103,10 @@ public class PCCopyToRepository extends PipelineComponent {
 
     @Override
     public void validate(String key) {
+        if (null == _repoDb) {
+            throw new IllegalStateException("Injector.injectMembers(this) has not been called");
+        }
+
         if (null == destinationContainerRepoDomain) {
             throw new AjaxClientException(
                 "Missing Param '" + key + ".destinationContainerRepoDomain' in request",
@@ -114,6 +118,19 @@ public class PCCopyToRepository extends PipelineComponent {
                 "Missing Param '" + key + ".destinationContainerRepoId' in request",
                 JsonError.Codes.MissingParam,
                 400);
+        }
+        ContainerRepo destinationRepo = _repoDb.getRepo(destinationContainerRepoDomain, destinationContainerRepoId);
+        if (null == destinationRepo) {
+            throw new AjaxClientException(String.format("Container repo not found for domain=%s and id=%s",
+                                                        destinationContainerRepoDomain,
+                                                        destinationContainerRepoId),
+                                          JsonError.Codes.BadParam,
+                                          400);
+        }
+        if (destinationRepo.isMirror()) {
+            throw new AjaxClientException("Cannot add a mirror repository to a pipeline",
+                                          JsonError.Codes.BadParam,
+                                          400);
         }
     }
 


### PR DESCRIPTION
This prevents users from adding a mirror repository as a pipeline component.
It both hides mirror repos from the dropdown in the UI as well as checking in
the backend before saving.