### PR TITLE
Update remote repo list when updating new creds

### DIFF
--- a/assets/js/actions/RegistryActions.js
+++ b/assets/js/actions/RegistryActions.js
@@ -207,7 +207,10 @@ export function updateNewRegistryField(prop, e, eIsValue = false) {
       if (prop == 'provider') getRegionsForProvider.call(this);
     });
   })
-};
+  .then(() => {
+    listReposForRegistry.call(this);
+  });
+}
 
 export function addRegistryRequest() {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
This updates the remote repositories list when the new registry credentials get
updated. Without this, the list on the mirror repos page never gets updated
when creating new credentials.