### PR TITLE
(WHO-1694, WHO-1779) auth token creation update (create on behalf of others and permissions)

### DIFF
--- a/assets/js/actions/SettingsActions.js
+++ b/assets/js/actions/SettingsActions.js
@@ -55,7 +55,8 @@ export function tokensState() {
     selectedTokenForStatusUpdate: null,
     selectedTokenForDelete: null,
     tokenItemError: null,
-    tokenPageError: null
+    tokenPageError: null,
+    isBlocked: false
   };
 }
 
@@ -91,6 +92,18 @@ export function listAuthTokens() {
     .catch((err) => {
       console.error(err);
       let errorMsg = `There was an error listing your API Tokens: ${err.error.message}`;
+      if(err.error.message == 'You do not have access to this operation') {
+        this.setState({
+          settings: Reducers(this.state.settings, {
+            type: 'UPDATE_TOKENS_STATE',
+            data: {
+              tokensXHR: false,
+              tokenPageError: errorMsg,
+              isBlocked: true
+            }
+          })
+        });
+      } else {
       this.setState({
         settings: Reducers(this.state.settings, {
           type: 'UPDATE_TOKENS_STATE',

--- a/assets/js/components/APITokens.js
+++ b/assets/js/components/APITokens.js
@@ -11,6 +11,7 @@ import Msg from './../components/Msg'
 import NPECheck from './../util/NPECheck'
 import ConvertTimeUTC from './../util/ConvertTimeUTC'
 import CopyToClipboard from './../util/CopyToClipboard'
+import AccessDenied from './../components/AccessDenied'
 
 export default class APITokens extends Component {
   constructor(props) {
@@ -70,10 +71,8 @@ export default class APITokens extends Component {
   }
 
   renderContent() {
-    let errorMsg = NPECheck(this.props, 'settings/tokens/tokenPageError', false);
-    if (errorMsg) {
-      return this.renderError(errorMsg);
-    }
+    let pageErrorMsg = NPECheck(this.props, 'settings/tokens/tokenPageError', false);
+    if (pageErrorMsg) return this.renderError(pageErrorMsg);
 
     let tokens = NPECheck(this.props, 'settings/tokens/allTokens', []);
     return (
@@ -192,15 +191,24 @@ export default class APITokens extends Component {
   }
 
   renderError(errorMsg) {
-    return (
-      <Msg text={errorMsg}
-           close={() => this.context.actions.clearTokenItemError()}
-           style={{padding: '1rem 0'}}/>
-    );
+    if(errorMsg)
+        return (
+          <Msg text={errorMsg}
+               close={() => this.context.actions.clearTokenItemError()}
+               style={{padding: '1rem 0'}}/>
+        );
   }
 
   renderPageContent() {
     let isLoading = NPECheck(this.props, 'settings/tokens/tokensXHR', false);
+    let isBlocked = NPECheck(this.props, 'settings/tokens/isBlocked', false);
+
+    if(isBlocked) {
+      return (
+        <AccessDenied/>
+      );
+    }
+
     if (isLoading) {
       return (
         <div className="PageLoader">
@@ -211,12 +219,14 @@ export default class APITokens extends Component {
 
     let tokens = NPECheck(this.props, 'settings/tokens/allTokens', []);
     if (!tokens.length) {
+      let itemErrorMsg = NPECheck(this.props, 'settings/tokens/tokenItemError', null);
       return (
         <div className="NoContent">
           <h3>No API Tokens found.</h3>
           <Btn className="LargeBlueButton"
                text="Create Token"
                onClick={() => this.createAuthToken()}/>
+          {this.renderError(itemErrorMsg)}
         </div>
       );
     }
@@ -228,6 +238,12 @@ export default class APITokens extends Component {
   }
 
   render() {
+    let isBlocked = NPECheck(this.props, 'settings/tokens/isBlocked', false);
+    if(isBlocked)
+      return (
+        <AccessDenied/>
+      );
+
     return (
       <div className="APITokens">
         {this.renderPageContent()}

--- a/src/main/java/com/distelli/europa/ajax/CreateAuthToken.java
+++ b/src/main/java/com/distelli/europa/ajax/CreateAuthToken.java
@@ -5,6 +5,7 @@ import javax.inject.Inject;
 import com.distelli.europa.Constants;
 import com.distelli.europa.db.TokenAuthDb;
 import com.distelli.europa.models.*;
+import com.distelli.europa.util.PermissionCheck;
 import com.distelli.persistence.PageIterator;
 import com.distelli.utils.CompactUUID;
 import com.distelli.webserver.AjaxHelper;
@@ -21,6 +22,8 @@ public class CreateAuthToken extends AjaxHelper<EuropaRequestContext>
 {
     @Inject
     protected TokenAuthDb _tokenAuthDb;
+    @Inject
+    private PermissionCheck _permissionCheck;
 
     public CreateAuthToken()
     {
@@ -29,6 +32,7 @@ public class CreateAuthToken extends AjaxHelper<EuropaRequestContext>
 
     public Object get(AjaxRequest ajaxRequest, EuropaRequestContext requestContext)
     {
+        _permissionCheck.check(ajaxRequest.getOperation(), requestContext);
         TokenAuth tokenAuth = TokenAuth
         .builder()
         .domain(requestContext.getOwnerDomain())

--- a/src/main/java/com/distelli/europa/ajax/CreateAuthToken.java
+++ b/src/main/java/com/distelli/europa/ajax/CreateAuthToken.java
@@ -31,7 +31,7 @@ public class CreateAuthToken extends AjaxHelper<EuropaRequestContext>
     {
         TokenAuth tokenAuth = TokenAuth
         .builder()
-        .domain(requestContext.getRequesterDomain())
+        .domain(requestContext.getOwnerDomain())
         .token(CompactUUID.randomUUID().toString())
         .status(TokenAuthStatus.ACTIVE)
         .created(System.currentTimeMillis())

--- a/src/main/java/com/distelli/europa/ajax/DeleteAuthToken.java
+++ b/src/main/java/com/distelli/europa/ajax/DeleteAuthToken.java
@@ -25,6 +25,8 @@ public class DeleteAuthToken extends AjaxHelper<EuropaRequestContext>
 {
     @Inject
     private TokenAuthDb _tokenAuthDb;
+    @Inject
+    private PermissionCheck _permissionCheck;
 
     public DeleteAuthToken()
     {
@@ -34,6 +36,7 @@ public class DeleteAuthToken extends AjaxHelper<EuropaRequestContext>
     public Object get(AjaxRequest ajaxRequest, EuropaRequestContext requestContext)
     {
         String token = ajaxRequest.getParam("token", true); //throw if missing
+        _permissionCheck.check(ajaxRequest.getOperation(), requestContext);
         try {
             _tokenAuthDb.deleteToken(requestContext.getOwnerDomain(), token);
         } catch(RollbackException rbe) {

--- a/src/main/java/com/distelli/europa/ajax/DeleteAuthToken.java
+++ b/src/main/java/com/distelli/europa/ajax/DeleteAuthToken.java
@@ -35,7 +35,7 @@ public class DeleteAuthToken extends AjaxHelper<EuropaRequestContext>
     {
         String token = ajaxRequest.getParam("token", true); //throw if missing
         try {
-            _tokenAuthDb.deleteToken(requestContext.getRequesterDomain(), token);
+            _tokenAuthDb.deleteToken(requestContext.getOwnerDomain(), token);
         } catch(RollbackException rbe) {
             throw(new AjaxClientException("Cannot Delete active Token", AjaxErrors.Codes.TokenIsActive, 400));
         }

--- a/src/main/java/com/distelli/europa/ajax/ListAuthTokens.java
+++ b/src/main/java/com/distelli/europa/ajax/ListAuthTokens.java
@@ -27,7 +27,7 @@ public class ListAuthTokens extends AjaxHelper<EuropaRequestContext>
 
     public Object get(AjaxRequest ajaxRequest, EuropaRequestContext requestContext)
     {
-        return _tokenAuthDb.getTokens(requestContext.getRequesterDomain(),
+        return _tokenAuthDb.getTokens(requestContext.getOwnerDomain(),
                                       new PageIterator().pageSize(1000));
     }
 }

--- a/src/main/java/com/distelli/europa/ajax/ListAuthTokens.java
+++ b/src/main/java/com/distelli/europa/ajax/ListAuthTokens.java
@@ -4,6 +4,7 @@ import javax.inject.Inject;
 
 import com.distelli.europa.Constants;
 import com.distelli.europa.db.TokenAuthDb;
+import com.distelli.europa.util.PermissionCheck;
 import com.distelli.persistence.PageIterator;
 import com.distelli.webserver.AjaxHelper;
 import com.distelli.webserver.AjaxRequest;
@@ -19,6 +20,8 @@ public class ListAuthTokens extends AjaxHelper<EuropaRequestContext>
 {
     @Inject
     private TokenAuthDb _tokenAuthDb;
+    @Inject
+    private PermissionCheck _permissionCheck;
 
     public ListAuthTokens()
     {
@@ -27,6 +30,7 @@ public class ListAuthTokens extends AjaxHelper<EuropaRequestContext>
 
     public Object get(AjaxRequest ajaxRequest, EuropaRequestContext requestContext)
     {
+        _permissionCheck.check(ajaxRequest.getOperation(), requestContext);
         return _tokenAuthDb.getTokens(requestContext.getOwnerDomain(),
                                       new PageIterator().pageSize(1000));
     }

--- a/src/main/java/com/distelli/europa/ajax/SetAuthTokenStatus.java
+++ b/src/main/java/com/distelli/europa/ajax/SetAuthTokenStatus.java
@@ -23,6 +23,8 @@ public class SetAuthTokenStatus extends AjaxHelper<EuropaRequestContext>
 {
     @Inject
     private TokenAuthDb _tokenAuthDb;
+    @Inject
+    protected PermissionCheck _permissionCheck;
 
     public SetAuthTokenStatus()
     {
@@ -31,6 +33,7 @@ public class SetAuthTokenStatus extends AjaxHelper<EuropaRequestContext>
 
     public Object get(AjaxRequest ajaxRequest, EuropaRequestContext requestContext)
     {
+        _permissionCheck.check(ajaxRequest.getOperation(), requestContext);
         TokenAuth tokenAuth = ajaxRequest.convertContent(TokenAuth.class, true);
         FieldValidator.validateNonNull(tokenAuth, "token", "status");
 

--- a/src/main/java/com/distelli/europa/ajax/SetAuthTokenStatus.java
+++ b/src/main/java/com/distelli/europa/ajax/SetAuthTokenStatus.java
@@ -34,7 +34,7 @@ public class SetAuthTokenStatus extends AjaxHelper<EuropaRequestContext>
         TokenAuth tokenAuth = ajaxRequest.convertContent(TokenAuth.class, true);
         FieldValidator.validateNonNull(tokenAuth, "token", "status");
 
-        _tokenAuthDb.setStatus(requestContext.getRequesterDomain(),
+        _tokenAuthDb.setStatus(requestContext.getOwnerDomain(),
                                tokenAuth.getToken(),
                                tokenAuth.getStatus());
         return JsonSuccess.Success;


### PR DESCRIPTION
In a nutshell, you can now create auth tokens on behalf of another user as long as that user has given you permission to do so. That user can also dole out other permissions concerning its auth tokens based on CRUD.

See https://github.com/puppetlabs/EuropaPremium/pull/37 for parallel changes in EuropaPremium